### PR TITLE
[Feat] 스쿼드 가져오기 및 수정하기 기능 구현

### DIFF
--- a/src/api/squad.js
+++ b/src/api/squad.js
@@ -63,3 +63,7 @@ export async function registerManualSquad(payload) {
   const response = await axios.post("/squads/manual", payload);
   return response.data;
 }
+
+export async function updateManualSquad(payload) {
+  return axios.put("/squads/manual", payload);
+}

--- a/src/features/squad/components/ExistSquadCard.vue
+++ b/src/features/squad/components/ExistSquadCard.vue
@@ -8,15 +8,12 @@ const { squad } = defineProps({
 
 const emit = defineEmits(["click"]);
 
-// 최대 표시할 멤버 수
 const maxVisibleMembers = 2;
 
-// 앞의 4명만 표시
 const displayedMembers = computed(() =>
   squad.members.slice(0, maxVisibleMembers),
 );
 
-// 숨겨진 멤버 수 계산
 const hiddenMemberCount = computed(() =>
   squad.members.length > maxVisibleMembers
     ? squad.members.length - maxVisibleMembers
@@ -28,20 +25,19 @@ const hiddenMemberCount = computed(() =>
   <div
     @click="emit('click')"
     :class="[
-      'relative rounded-lg p-4 shadow-lg flex flex-col h-[350px] w-[260px] mt-2',
-      squad.aiRecommended
-        ? 'bg-white border-0 p-[2px] bg-gradient-to-r from-purple-500 to-sky-400'
-        : 'border border-gray-200 bg-white',
-      isSelected ? 'bg-[#F6F7FE]' : '',
+      'relative rounded-lg p-4 flex flex-col h-[350px] w-[260px] mt-2 cursor-pointer transition-transform duration-200 hover:scale-[1.02]',
+      isSelected
+        ? 'bg-blue-50 border-2 border-primary shadow-lg'
+        : squad.aiRecommended
+          ? 'bg-white border-0 p-[2px] bg-gradient-to-r from-purple-500 to-sky-400'
+          : 'bg-white border border-gray-200 shadow-lg',
     ]"
   >
-    <!-- 내부 카드 내용 (AI는 한겹 더 감싸기) -->
     <div
       :class="[
-        squad.aiRecommended
+        squad.aiRecommended && !isSelected
           ? 'h-full rounded-lg bg-white p-4 relative'
           : 'contents',
-        isSelected ? 'bg-[#F6F7FE]' : '',
       ]"
     >
       <!-- AI 추천 배지 -->
@@ -66,15 +62,20 @@ const hiddenMemberCount = computed(() =>
           <li
             v-for="(member, index) in displayedMembers"
             :key="index"
-            class="bg-gray-100 text-sm px-2 py-1 mb-2 rounded-lg w-fit"
+            :class="[
+              'text-sm px-2 py-1 mb-2 rounded-lg w-fit',
+              isSelected ? 'bg-white font-bold' : 'bg-gray-100',
+            ]"
           >
             {{ member.name }} - {{ member.job }}
           </li>
 
-          <!-- 더 많은 멤버가 있을 경우 -->
           <li
             v-if="hiddenMemberCount > 0"
-            class="bg-gray-100 text-sm px-2 py-1 mb-1 rounded-lg w-fit"
+            :class="[
+              'text-sm px-2 py-1 mb-1 rounded-lg w-fit',
+              isSelected ? 'bg-white font-bold' : 'bg-gray-100',
+            ]"
           >
             ... 외 {{ hiddenMemberCount }}명
           </li>
@@ -84,12 +85,16 @@ const hiddenMemberCount = computed(() =>
       <!-- 예상 기간 / 예산 -->
       <div class="text-sm mt-6 text-left flex flex-col">
         <span class="font-medium">예상 기간:</span>
-        <span class="ml-1">{{ squad.estimatedPeriod || "-" }}</span>
+        <span :class="[isSelected ? 'font-bold' : '']" class="ml-1">
+          {{ squad.estimatedPeriod || "-" }}
+        </span>
       </div>
 
       <div class="text-sm my-6 text-left flex flex-col">
         <span class="font-medium">예상 예산:</span>
-        <span class="ml-1">{{ squad.estimatedCost || "-" }}</span>
+        <span :class="[isSelected ? 'font-bold' : '']" class="ml-1">
+          {{ squad.estimatedCost || "-" }}
+        </span>
       </div>
     </div>
   </div>

--- a/src/stores/squadCreateStore.js
+++ b/src/stores/squadCreateStore.js
@@ -1,36 +1,46 @@
 import { defineStore } from "pinia";
-import { ref } from "vue";
+import { ref, computed } from "vue";
 
 export const useSquadStore = defineStore("squad", () => {
-  // 스쿼드 구성원 목록
   const selectedMembers = ref([]);
 
-  // 개발자 추가 (중복 방지)
-  function addMember(member) {
+  const selectedSquadInfo = ref({
+    id: null, // 수정 중인 스쿼드 ID
+    title: "", // 스쿼드 제목
+    description: "", // 스쿼드 설명
+  });
+
+  const isEditMode = computed(() => selectedSquadInfo.value.id !== null);
+
+  const addMember = (member) => {
+    console.log(member);
     const exists = selectedMembers.value.some((m) => m.id === member.id);
     if (!exists) {
       selectedMembers.value.push(member);
     }
-  }
+  };
 
-  // 개발자 제거
-  function removeMember(memberId) {
+  const removeMember = (employeeId) => {
     selectedMembers.value = selectedMembers.value.filter(
-      (m) => m.id !== memberId,
+      (m) => m.id !== employeeId,
     );
-    console.log(memberId);
-    console.log(selectedMembers.value);
-  }
+  };
 
-  // 전체 초기화
-  function clearMembers() {
+  const resetSquad = () => {
     selectedMembers.value = [];
-  }
+    selectedSquadInfo.value = {
+      id: null,
+      title: "",
+      description: "",
+    };
+  };
 
   return {
     selectedMembers,
     addMember,
     removeMember,
-    clearMembers,
+    selectedSquadInfo,
+    isEditMode,
+    resetSquad,
   };
 });


### PR DESCRIPTION
## 🛰️ Issue
Closes #114 

## 🪐 작업 내용
### 1. 기존 스쿼드 가져오기
- 기존 스쿼드 선택 모달을 사용하여 기존 스쿼드를 가져와서 하나의 스쿼드를 선택 해당 스쿼드에 대한 suadCode를 추출했습니다. 
- 기존 스쿼드 선택 모달은 선택한 스쿼드에 대한 표시가 없어서 추가적으로 스쿼드 선택에 대한 트랜지션을 추가 구현했습니다. 
- suadCode로 스쿼드 상세 조회 api를 연결하여 기존 스쿼드 구성원 및 메타 정보를 추출하여 스쿼드 수정에 필요한 데이터를 세팅했습니다. 

### 2. 스쿼드 수정하기
- 기존 squadStore에 isEditMode와 스쿼드 메타 정보를 추가적으로 관리할 수 있도록 구현했습니다. 
- 기존 squadCreateSection에서 수정/등록 분기 처리하여 isEditMode가 true일땐 update api를 호출할 수 있도록 구현했습니다. 

<br>

## ✅ 체크리스트
- [o] 이슈 완료
- [x] cypress 통합테스트
- [x] vitest 단위테스트
