### PR TITLE
[Feat] 프로젝트 인원 보충 기능 구현

### DIFF
--- a/src/api/project.js
+++ b/src/api/project.js
@@ -107,7 +107,7 @@ export function fetchFunctionTypes() {
 }
 
 export function replaceProjectSquad(payload) {
-  return api.put("/projects/replacement", payload);
+  return api.put("/projects/squad/replacement", payload);
 }
 
 export function replaceRecommendation(payload) {

--- a/src/api/project.js
+++ b/src/api/project.js
@@ -105,3 +105,11 @@ export function getProjectInfo(id) {
 export function fetchFunctionTypes() {
   return api.get("/dev-project-works/function-types");
 }
+
+export function replaceProjectSquad(payload) {
+  return api.put("/projects/replacement", payload);
+}
+
+export function replaceRecommendation(payload) {
+  return api.post("/projects/replacement", payload);
+}

--- a/src/components/header/AuthMenu.vue
+++ b/src/components/header/AuthMenu.vue
@@ -70,8 +70,8 @@ const notificationStore = useNotificationStore();
       <div class="profile" @click="openModal">
         <img :src="BasicProfile" alt="기본프로필이미지" />
         <span
-          v-if="notificationStore.hasUnreadNotification"
-          class="absolute top-[6px] right-[-1px] w-2.5 h-2.5 rounded-full bg-red-500"
+          v-if="notificationStore"
+          class="absolute top-[6px] right-[-1px] w-2 h-2 rounded-full bg-red-500 animate-bounce"
         ></span>
       </div>
 

--- a/src/features/project/components/ReplacementDeveloperSearch.vue
+++ b/src/features/project/components/ReplacementDeveloperSearch.vue
@@ -115,7 +115,10 @@ function renderSummary() {
 }
 
 function handleReplace(dev) {
-  emit("replace", dev); // 단순하게 선택한 개발자 객체 전달
+  emit("replace", {
+    oldMemberId: props.leavingMember.employeeId,
+    newMemberId: dev.value.employeeId,
+  });
 }
 
 onMounted(() => {

--- a/src/features/project/components/ReplacementDeveloperSearch.vue
+++ b/src/features/project/components/ReplacementDeveloperSearch.vue
@@ -1,0 +1,284 @@
+<script setup>
+import { ref, onMounted, onBeforeUnmount } from "vue";
+import FilterModal from "@/features/squad/components/modal/FilterModal.vue";
+import SortModal from "@/features/squad/components/modal/SortModal.vue";
+import BasePagination from "@/components/Pagination.vue";
+import { searchSquadDevelopers } from "@/api/squad.js";
+
+const props = defineProps({
+  project: Object,
+  leavingMember: Object,
+});
+const emit = defineEmits(["replace"]);
+
+const searchQuery = ref("");
+const developers = ref([]);
+const currentPage = ref(1);
+const totalPages = ref(1);
+
+const isFocused = ref(false);
+const showFilter = ref(false);
+const showSort = ref(false);
+
+const selectedFilters = ref({
+  techStacks: [],
+  grades: [],
+  statuses: [],
+  freelancer: null,
+  sortBy: "",
+  sortOrder: "",
+});
+
+async function handleSearch(page = 1) {
+  const payload = {
+    keyword: searchQuery.value,
+    status: selectedFilters.value.statuses[0] || null,
+    grades: selectedFilters.value.grades,
+    stacks: selectedFilters.value.techStacks,
+    memberRoles: selectedFilters.value.freelancer
+      ? [selectedFilters.value.freelancer]
+      : [],
+    sortBy: selectedFilters.value.sortBy || "grade",
+    sortDir: selectedFilters.value.sortOrder || "asc",
+    page: page - 1,
+    size: 10,
+  };
+
+  try {
+    const result = await searchSquadDevelopers(payload);
+    developers.value = result.content.map((dev) => ({
+      id: dev.employeeId,
+      name: dev.name,
+      grade: dev.grade,
+      status: dev.status === "AVAILABLE" ? "대기중" : "투입중",
+      techStack: [dev.topTechStackName],
+    }));
+
+    currentPage.value = result.currentPage + 1;
+    totalPages.value = result.totalPages;
+  } catch (e) {
+    developers.value = [];
+    currentPage.value = 1;
+    totalPages.value = 1;
+  }
+}
+
+function removeTechStack(stack) {
+  selectedFilters.value.techStacks = selectedFilters.value.techStacks.filter(
+    (s) => s !== stack,
+  );
+}
+
+function addTechStack(stack) {
+  if (!selectedFilters.value.techStacks.includes(stack)) {
+    selectedFilters.value.techStacks.push(stack);
+  }
+}
+
+function toggleFilter() {
+  showSort.value = false;
+  showFilter.value = !showFilter.value;
+}
+function toggleSort() {
+  showFilter.value = false;
+  showSort.value = !showSort.value;
+}
+
+function handleDocumentClick(e) {
+  const filterModal = document.getElementById("filterModal");
+  const sortModal = document.getElementById("sortModal");
+  if (filterModal && !filterModal.contains(e.target)) {
+    showFilter.value = false;
+  }
+  if (sortModal && !sortModal.contains(e.target)) {
+    showSort.value = false;
+  }
+}
+
+function renderSummary() {
+  const parts = [];
+
+  if (selectedFilters.value.techStacks.length)
+    parts.push(selectedFilters.value.techStacks.join(", "));
+  if (selectedFilters.value.grades.length)
+    parts.push(selectedFilters.value.grades.join(", "));
+  if (selectedFilters.value.statuses.length)
+    parts.push(selectedFilters.value.statuses.join(", "));
+  if (selectedFilters.value.freelancer)
+    parts.push(selectedFilters.value.freelancer);
+  if (selectedFilters.value.sortBy || selectedFilters.value.sortOrder)
+    parts.push(
+      `${selectedFilters.value.sortBy}-${selectedFilters.value.sortOrder}`,
+    );
+
+  return parts.join(" / ");
+}
+
+function handleReplace(dev) {
+  emit("replace", dev); // 단순하게 선택한 개발자 객체 전달
+}
+
+onMounted(() => {
+  document.addEventListener("click", handleDocumentClick);
+  handleSearch();
+});
+onBeforeUnmount(() => {
+  document.removeEventListener("click", handleDocumentClick);
+});
+</script>
+
+<template>
+  <div>
+    <!-- 검색바 -->
+    <div class="search-bar" :class="{ focused: isFocused }">
+      <input
+        v-model="searchQuery"
+        type="text"
+        placeholder="개발자를 검색해주세요"
+        class="search-input"
+        @focus="isFocused = true"
+        @blur="isFocused = false"
+        @keyup.enter="handleSearch"
+      />
+
+      <div class="relative">
+        <button class="btn-icon" @click.stop="toggleFilter">
+          <i class="fa-solid fa-filter"></i>
+        </button>
+        <FilterModal
+          v-if="showFilter"
+          :selectedFilters="selectedFilters"
+          @removeTechStack="removeTechStack"
+          @addTechStack="addTechStack"
+        />
+      </div>
+
+      <div class="relative">
+        <button class="btn-icon" @click.stop="toggleSort">
+          <i class="fa-solid fa-align-center"></i>
+        </button>
+        <SortModal v-if="showSort" :selectedFilters="selectedFilters" />
+      </div>
+
+      <button class="btn-icon" @click="handleSearch">
+        <i class="fa-solid fa-magnifying-glass"></i>
+      </button>
+    </div>
+
+    <div class="filter-summary">
+      <div class="overflow-hidden whitespace-nowrap text-ellipsis">
+        {{ renderSummary() }}
+      </div>
+    </div>
+
+    <div class="table-wrapper">
+      <template v-if="developers.length > 0">
+        <table class="dev-table">
+          <thead>
+            <tr>
+              <th>번호</th>
+              <th>개발자명</th>
+              <th>등급</th>
+              <th>상태</th>
+              <th>기술스택</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="(dev, index) in developers"
+              :key="dev.id"
+              class="hover:bg-gray-50 cursor-pointer"
+            >
+              <td class="text-center">{{ index + 1 }}</td>
+              <td class="text-center">{{ dev.name }}</td>
+              <td class="text-center font-bold">{{ dev.grade }}</td>
+              <td class="text-center">
+                <span class="status-badge">{{ dev.status }}</span>
+              </td>
+              <td class="text-center">
+                <div class="stack-list">
+                  <span
+                    v-for="stack in dev.techStack"
+                    :key="stack"
+                    class="stack-badge"
+                  >
+                    {{ stack }}
+                  </span>
+                </div>
+              </td>
+              <td class="text-center">
+                <button class="btn-add" @click="handleReplace(dev)">
+                  교체
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </template>
+      <template v-else>
+        <div class="empty-message">검색한 개발자가 없습니다</div>
+      </template>
+    </div>
+
+    <div class="flex justify-center">
+      <BasePagination
+        :current-page="currentPage"
+        :total-pages="totalPages"
+        @change="handleSearch"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.search-bar {
+  @apply flex items-center gap-2 mb-4 px-3 py-2 border border-gray-300 rounded transition relative;
+}
+.search-bar.focused {
+  @apply border-primary ring-2 ring-primary/30;
+}
+.search-input {
+  @apply flex-1 outline-none border-none bg-transparent;
+}
+.btn-icon {
+  @apply px-4 py-3 text-sm hover:bg-gray-100 rounded;
+}
+.filter-summary {
+  @apply mb-3 text-sm text-gray-600 max-w-full overflow-hidden;
+}
+.table-wrapper {
+  @apply h-[500px] overflow-y-auto border border-gray-200 relative mb-4;
+}
+.dev-table {
+  @apply w-full border-collapse text-sm text-center;
+}
+.dev-table thead th {
+  @apply bg-gray-100 text-gray-800 py-2 border-b border-gray-300;
+}
+.dev-table tbody td {
+  @apply py-2 border-b border-gray-100;
+}
+.status-badge {
+  @apply inline-block px-2 py-1 text-xs bg-yellow-200 text-yellow-800 rounded;
+}
+.stack-list {
+  @apply flex justify-center gap-1 flex-wrap;
+}
+.stack-badge {
+  @apply px-2 py-1 bg-gray-200 text-xs rounded;
+}
+.btn-add {
+  @apply px-5 py-2 bg-white text-primary border border-primary shadow-sm rounded text-sm font-bold hover:bg-gray-50 transition;
+}
+
+.pagination button {
+  @apply px-2 py-1 text-sm border border-gray-300 rounded hover:bg-gray-100;
+}
+.pagination .active {
+  @apply bg-primary text-white;
+}
+.empty-message {
+  @apply absolute inset-0 flex items-center justify-center text-gray-400;
+}
+</style>

--- a/src/features/project/components/ReplacementPanel.vue
+++ b/src/features/project/components/ReplacementPanel.vue
@@ -1,0 +1,121 @@
+<script setup>
+import { computed, ref } from "vue";
+import ReplacementDeveloperSearch from "@/features/project/components/ReplacementDeveloperSearch.vue";
+import ReplacementSearchPanel from "@/features/project/components/ReplacementSearchPanel.vue";
+import AiLoadingOverlay from "@/components/AiLoadingOverlay.vue"; // 필요시 위치 조정
+
+const props = defineProps({
+  project: Object,
+  leavingMember: Object,
+});
+
+const visible = computed(() => props.project && props.leavingMember);
+defineEmits(["close", "replace"]);
+
+const activeTab = ref("manual");
+const isLoading = ref(false);
+const showAISection = ref(false);
+
+function switchToAI() {
+  activeTab.value = "ai";
+  isLoading.value = false;
+  showAISection.value = true;
+
+  // setTimeout(() => {
+  //   isLoading.value = false;
+  //   showAISection.value = true;
+  // }, 3000);
+}
+</script>
+
+<template>
+  <transition name="slide">
+    <div v-if="visible" class="fixed inset-0 z-50">
+      <div class="absolute inset-0 opacity-30" @click="$emit('close')"></div>
+
+      <div
+        class="absolute top-0 right-0 w-[650px] h-full bg-white border-l shadow-xl z-50 p-6 overflow-y-auto"
+        @click.stop
+      >
+        <h2 class="text-xl font-bold mb-2">인재 대체</h2>
+        <p class="text-sm text-gray-600 mb-4">
+          <strong>{{ leavingMember.name }}</strong> 님을 대체할 인재를
+          선택하세요.
+        </p>
+
+        <!-- 탭 -->
+        <div class="flex gap-3 mb-4">
+          <button
+            :class="['tab-btn', activeTab === 'manual' ? 'active' : '']"
+            @click="activeTab = 'manual'"
+          >
+            직접 조회
+          </button>
+          <button
+            :class="['tab-btn', activeTab === 'ai' ? 'active' : '']"
+            @click="switchToAI"
+          >
+            AI 추천
+          </button>
+        </div>
+
+        <ReplacementDeveloperSearch
+          v-if="activeTab === 'manual'"
+          :project="project"
+          :leaving-member="leavingMember"
+          @replace="(payload) => $emit('replace', payload)"
+        />
+
+        <AiLoadingOverlay
+          :visible="isLoading"
+          message="AI 분석 기반 <strong>추천 인재 탐색</strong>이 진행중입니다..."
+        />
+
+        <transition name="fade">
+          <ReplacementSearchPanel
+            v-if="activeTab === 'ai' && showAISection"
+            :project="project"
+            :leaving-member="leavingMember"
+            @replace="(payload) => $emit('replace', payload)"
+          />
+        </transition>
+
+        <div class="mt-6 flex justify-end">
+          <button @click="$emit('close')" class="text-sm text-gray-500">
+            닫기
+          </button>
+        </div>
+      </div>
+    </div>
+  </transition>
+</template>
+
+<style scoped>
+.slide-enter-active,
+.slide-leave-active {
+  transition: all 0.3s ease-in-out;
+}
+.slide-enter-from {
+  transform: translateX(100%);
+  opacity: 0;
+}
+.slide-enter-to {
+  transform: translateX(0);
+  opacity: 1;
+}
+.slide-leave-from {
+  transform: translateX(0);
+  opacity: 1;
+}
+.slide-leave-to {
+  transform: translateX(100%);
+  opacity: 0;
+}
+
+.tab-btn {
+  @apply px-4 py-2 border rounded text-sm font-medium;
+}
+.tab-btn.active {
+  @apply bg-primary text-white border-primary;
+}
+</style>

--- a/src/features/project/components/ReplacementPanel.vue
+++ b/src/features/project/components/ReplacementPanel.vue
@@ -21,10 +21,10 @@ function switchToAI() {
   isLoading.value = false;
   showAISection.value = true;
 
-  // setTimeout(() => {
-  //   isLoading.value = false;
-  //   showAISection.value = true;
-  // }, 3000);
+  setTimeout(() => {
+    isLoading.value = false;
+    showAISection.value = true;
+  }, 1000);
 }
 </script>
 

--- a/src/features/project/components/ReplacementSearchPanel.vue
+++ b/src/features/project/components/ReplacementSearchPanel.vue
@@ -1,3 +1,58 @@
+<script setup>
+import { ref, onMounted } from "vue";
+import { replaceRecommendation } from "@/api/project.js";
+import { useRoute } from "vue-router";
+
+const props = defineProps({
+  project: Object,
+  leavingMember: Object,
+});
+
+const emit = defineEmits(["replace"]);
+
+const candidates = ref([]);
+const selected = ref(null);
+const isLoading = ref(true);
+
+const select = (dev) => {
+  selected.value = dev;
+};
+
+const emitReplace = () => {
+  emit("replace", {
+    oldMemberId: props.leavingMember.employeeId,
+    newMemberId: selected.value.id,
+  });
+};
+
+const route = useRoute();
+const projectCode = route.params.projectCode;
+
+onMounted(async () => {
+  try {
+    const response = await replaceRecommendation({
+      projectCode: projectCode,
+      leavingMember: props.leavingMember.employeeId,
+    });
+    candidates.value = response.data.data;
+  } catch (e) {
+    console.error("추천 인재 조회 실패", e);
+  } finally {
+    isLoading.value = false;
+  }
+});
+</script>
+
+<style scoped>
+/* Glow 효과 */
+.glow {
+  box-shadow:
+    0 0 8px rgba(101, 116, 246, 0.6),
+    0 0 12px rgba(101, 116, 246, 0.4),
+    0 0 20px rgba(101, 116, 246, 0.2);
+}
+</style>
+
 <template>
   <div>
     <h3 class="text-sm font-semibold mb-4">최적 인재 추천</h3>
@@ -64,58 +119,3 @@
     </button>
   </div>
 </template>
-
-<script setup>
-import { ref, onMounted } from "vue";
-import { replaceRecommendation } from "@/api/project.js";
-import { useRoute } from "vue-router";
-
-const props = defineProps({
-  project: Object,
-  leavingMember: Object,
-});
-
-const emit = defineEmits(["replace"]);
-
-const candidates = ref([]);
-const selected = ref(null);
-const isLoading = ref(true);
-
-const select = (dev) => {
-  selected.value = dev;
-};
-
-const emitReplace = () => {
-  emit("replace", {
-    oldMember: props.leavingMember,
-    newMember: selected.value,
-  });
-};
-
-const route = useRoute();
-const projectCode = route.params.projectCode;
-
-onMounted(async () => {
-  try {
-    const response = await replaceRecommendation({
-      projectCode: projectCode,
-      leavingMember: props.leavingMember.employeeId,
-    });
-    candidates.value = response.data.data;
-  } catch (e) {
-    console.error("추천 인재 조회 실패", e);
-  } finally {
-    isLoading.value = false;
-  }
-});
-</script>
-
-<style scoped>
-/* Glow 효과 */
-.glow {
-  box-shadow:
-    0 0 8px rgba(101, 116, 246, 0.6),
-    0 0 12px rgba(101, 116, 246, 0.4),
-    0 0 20px rgba(101, 116, 246, 0.2);
-}
-</style>

--- a/src/features/project/components/ReplacementSearchPanel.vue
+++ b/src/features/project/components/ReplacementSearchPanel.vue
@@ -1,0 +1,121 @@
+<template>
+  <div>
+    <h3 class="text-sm font-semibold mb-4">최적 인재 추천</h3>
+
+    <div v-if="isLoading" class="text-gray-500">
+      추천 인재를 불러오는 중입니다...
+    </div>
+    <div v-else-if="candidates.length === 0" class="text-sm text-gray-400">
+      추천 인재가 없습니다.
+    </div>
+
+    <div v-else class="flex flex-col gap-4">
+      <div
+        v-for="(dev, index) in candidates.slice(0, 5)"
+        :key="dev.id"
+        @click="select(dev)"
+        :class="[
+          'p-4 rounded-xl shadow transition-all duration-200 cursor-pointer group border-2',
+          selected?.id === dev.id
+            ? 'border-blue-600 ring-2 ring-blue-200'
+            : 'border-gray-200',
+          index === 0 ? 'shadow-xl glow' : '',
+        ]"
+      >
+        <!-- 이름 -->
+        <div
+          class="text-lg font-bold text-gray-900 mb-3 group-hover:underline tracking-tight"
+        >
+          {{ index + 1 }}위 · {{ dev.name }}
+        </div>
+
+        <!-- 정보 박스 3개 -->
+        <div class="flex gap-3">
+          <div
+            class="flex-1 rounded-md bg-blue-100 text-blue-800 font-semibold text-center py-2 text-sm shadow-inner"
+          >
+            기술점수<br />
+            <span class="text-xl">{{ dev.avgTechScore.toFixed(1) }}</span>
+          </div>
+
+          <div
+            class="flex-1 rounded-md bg-green-100 text-green-800 font-semibold text-center py-2 text-sm shadow-inner"
+          >
+            도메인 경험<br />
+            <span class="text-xl">{{ dev.domainCount }}</span>
+          </div>
+
+          <div
+            class="flex-1 rounded-md text-rose-500 font-semibold text-center py-2 text-sm shadow-inner bg-rose-100"
+          >
+            등급<br />
+            <span class="text-xl">{{ dev.grade }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <button
+      :disabled="!selected"
+      class="mt-6 w-full bg-primary text-white py-2 rounded disabled:opacity-50"
+      @click="emitReplace"
+    >
+      선택한 인재로 대체하기
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from "vue";
+import { replaceRecommendation } from "@/api/project.js";
+import { useRoute } from "vue-router";
+
+const props = defineProps({
+  project: Object,
+  leavingMember: Object,
+});
+
+const emit = defineEmits(["replace"]);
+
+const candidates = ref([]);
+const selected = ref(null);
+const isLoading = ref(true);
+
+const select = (dev) => {
+  selected.value = dev;
+};
+
+const emitReplace = () => {
+  emit("replace", {
+    oldMember: props.leavingMember,
+    newMember: selected.value,
+  });
+};
+
+const route = useRoute();
+const projectCode = route.params.projectCode;
+
+onMounted(async () => {
+  try {
+    const response = await replaceRecommendation({
+      projectCode: projectCode,
+      leavingMember: props.leavingMember.employeeId,
+    });
+    candidates.value = response.data.data;
+  } catch (e) {
+    console.error("추천 인재 조회 실패", e);
+  } finally {
+    isLoading.value = false;
+  }
+});
+</script>
+
+<style scoped>
+/* Glow 효과 */
+.glow {
+  box-shadow:
+    0 0 8px rgba(101, 116, 246, 0.6),
+    0 0 12px rgba(101, 116, 246, 0.4),
+    0 0 20px rgba(101, 116, 246, 0.2);
+}
+</style>

--- a/src/features/project/components/SquadCard.vue
+++ b/src/features/project/components/SquadCard.vue
@@ -1,13 +1,16 @@
 <template>
   <div
     :class="[
-      'flex items-center justify-between px-6 py-4 transition-all duration-200 cursor-pointer',
-      selected
-        ? 'bg-yellow-50 border-yellow-400 border-2 rounded-md'
-        : isReplacementMode
-          ? 'hover:bg-yellow-50'
-          : 'bg-[#F7FAFC]',
+      'flex items-center justify-between px-6 py-4 transition-all duration-200',
+      isLeader === 1
+        ? 'cursor-not-allowed opacity-50 bg-gray-100'
+        : selected
+          ? 'cursor-pointer bg-yellow-50 border-yellow-400 border-2 rounded-md'
+          : isReplacementMode
+            ? 'cursor-pointer hover:bg-yellow-50'
+            : 'cursor-pointer bg-[#F7FAFC]',
     ]"
+    @click="handleClick"
   >
     <!-- 프로필 + 이름/직무 -->
     <div class="flex items-center gap-4">
@@ -36,7 +39,9 @@
 </template>
 
 <script setup>
-defineProps({
+const emit = defineEmits(["click"]);
+
+const props = defineProps({
   name: String,
   role: String,
   isLeader: Number,
@@ -50,4 +55,10 @@ defineProps({
     default: false,
   },
 });
+
+function handleClick() {
+  // 리더일 경우 클릭 방지
+  if (props.isLeader === 1) return;
+  emit("click");
+}
 </script>

--- a/src/features/project/components/SquadCard.vue
+++ b/src/features/project/components/SquadCard.vue
@@ -1,5 +1,14 @@
 <template>
-  <div class="flex items-center justify-between px-6 py-4 bg-[#F7FAFC]">
+  <div
+    :class="[
+      'flex items-center justify-between px-6 py-4 transition-all duration-200 cursor-pointer',
+      selected
+        ? 'bg-yellow-50 border-yellow-400 border-2 rounded-md'
+        : isReplacementMode
+          ? 'hover:bg-yellow-50'
+          : 'bg-[#F7FAFC]',
+    ]"
+  >
     <!-- 프로필 + 이름/직무 -->
     <div class="flex items-center gap-4">
       <img
@@ -32,5 +41,13 @@ defineProps({
   role: String,
   isLeader: Number,
   imageUrl: String,
+  selected: {
+    type: Boolean,
+    default: false,
+  },
+  isReplacementMode: {
+    type: Boolean,
+    default: false,
+  },
 });
 </script>

--- a/src/features/project/views/ProjectDetailView.vue
+++ b/src/features/project/views/ProjectDetailView.vue
@@ -29,7 +29,7 @@ onMounted(async () => {
     project.value = response.data.data;
 
     if (project.value?.members?.length > 0) {
-      replacingMember.value = project.value.members[0];
+      replacingMember.value = project.value.members[1];
       console.log(replacingMember.value);
     }
   } catch (error) {
@@ -102,22 +102,22 @@ const handleMemberClick = (member) => {
   }
 };
 
-const handleReplace = async ({ oldMember, newMember }) => {
+const handleReplace = async ({ oldMemberId, newMemberId }) => {
   try {
     await replaceProjectSquad({
       squadCode: project.value.squadCode,
-      oldEmployeeId: oldMember.employeeId,
-      newEmployeeId: newMember.employeeId,
+      oldEmployeeId: oldMemberId,
+      newEmployeeId: newMemberId,
     });
-    showSuccessToast("인재가 성공적으로 대체되었습니다.");
+    showSuccessToast("프로젝트 인원이 성공적으로 대체되었습니다.");
     isReplacementVisible.value = false;
     isReplacementMode.value = false;
 
     const response = await fetchProjectDetail(projectCode);
     project.value = response.data.data;
   } catch (e) {
-    console.error("인재 대체 실패", e);
-    showErrorToast("대체에 실패했습니다.");
+    console.error("프로젝트 인원 대체 실패", e);
+    showErrorToast("프로젝트 인원 대체에 실패했습니다.");
   }
 };
 </script>
@@ -328,6 +328,7 @@ const handleReplace = async ({ oldMember, newMember }) => {
       </div>
     </transition>
     <ReplacementPanel
+      :key="replacingMember?.employeeId"
       :project="project"
       v-show="isReplacementVisible"
       :leaving-member="replacingMember"

--- a/src/features/squad/router.js
+++ b/src/features/squad/router.js
@@ -5,6 +5,7 @@ export const squadRoutes = [
     component: () => import("./views/SquadListView.vue"),
     meta: {
       requiresAuth: true,
+      roles: ["ADMIN"],
     },
   },
   {
@@ -13,6 +14,7 @@ export const squadRoutes = [
     component: () => import("./views/SquadDetailView.vue"),
     meta: {
       requiresAuth: true,
+      roles: ["ADMIN"],
     },
   },
   {
@@ -21,6 +23,7 @@ export const squadRoutes = [
     component: () => import("./views/SquadCreateView.vue"),
     meta: {
       requiresAuth: true,
+      roles: ["ADMIN"],
     },
   },
 
@@ -30,6 +33,7 @@ export const squadRoutes = [
     component: () => import("@/features/project/views/ProjectRegisterView.vue"),
     meta: {
       requiresAuth: true,
+      roles: ["ADMIN"],
     },
   },
 ];

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -49,7 +49,6 @@ const router = createRouter({
 // 전역 가드: 인증 · 권한 · guestOnly · 로그인/회원가입 접근 제어
 router.beforeEach((to, from) => {
   const authStore = useAuthStore();
-
   // 1) 인증 필요 페이지인데 비로그인
   if (to.meta.requiresAuth && !authStore.isAuthenticated) {
     showErrorToast("로그인이 필요한 페이지입니다.");
@@ -72,6 +71,8 @@ router.beforeEach((to, from) => {
 
   // 4) roles 메타로 권한 체크
   const { roles } = to.meta;
+  console.log(roles);
+  console.log(authStore.memberRole);
   if (
     Array.isArray(roles) &&
     roles.length > 0 &&


### PR DESCRIPTION
## 🪐 작업 내용
- 프로젝트 진행 상태에 따라 진행 전에는 기존 스쿼드 수정 처럼 스쿼드 전체를 한번에 수정할 수 있도록 스쿼드 수정 페이지로 이동하게 했고 프로젝트가 진행하면 멤버를 대체하는 기능으로 구현했습니다. 
- 인원 대체 버튼 클릭 -> 대체 가능한 상태가 되고 이 상황에서 대체 가능한 멤버를 클릭하면 개발자를 검색할 수 있거나 추천 받을 수 있는 패널이 슬라이드로 등장하도록 구현했습니다. 


## 📚 논의하고 싶은 내용 (선택)
- 선택사항


<br>

## ✅ 체크리스트
- [o] 이슈 완료
- [x] cypress 통합테스트
- [x] vitest 단위테스트
