### PR TITLE
[Feat] 관리자 메인 대시보드 / 프로젝트 인원 보충 / 프로젝트 평가 기능 구현

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -1,4 +1,5 @@
 import api from "./axios.js";
+import axios from "axios";
 
 export function getAllJobs() {
   return api.get("/jobs");
@@ -64,4 +65,8 @@ export function updateClient(clientCode, data) {
 
 export function deleteClient(clientCode) {
   return api.delete(`/client-companies/${clientCode}`);
+}
+
+export async function getAdminMainDashboard() {
+  return api.get("/members/dashboard-summary");
 }

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -1,5 +1,4 @@
 import api from "./axios.js";
-import axios from "axios";
 
 export function getAllJobs() {
   return api.get("/jobs");

--- a/src/api/project.js
+++ b/src/api/project.js
@@ -115,3 +115,11 @@ export function getProjectInfo(id) {
 export function fetchFunctionTypes() {
   return api.get("/dev-project-works/function-types");
 }
+
+export function replaceProjectSquad(payload) {
+  return api.put("/projects/replacement", payload);
+}
+
+export function replaceRecommendation(payload) {
+  return api.post("/projects/replacement", payload);
+}

--- a/src/api/project.js
+++ b/src/api/project.js
@@ -123,3 +123,7 @@ export function replaceProjectSquad(payload) {
 export function replaceRecommendation(payload) {
   return api.post("/projects/replacement", payload);
 }
+
+export function fetchDeveloperApprovals(projectCode) {
+  return api.get(`/projects/${projectCode}/developer-approvals`);
+}

--- a/src/api/project.js
+++ b/src/api/project.js
@@ -117,7 +117,7 @@ export function fetchFunctionTypes() {
 }
 
 export function replaceProjectSquad(payload) {
-  return api.put("/projects/replacement", payload);
+  return api.put("/projects/squad/replacement", payload);
 }
 
 export function replaceRecommendation(payload) {

--- a/src/features/admin/components/dashboard/DeveloperAvailability.vue
+++ b/src/features/admin/components/dashboard/DeveloperAvailability.vue
@@ -60,7 +60,7 @@ const enrichedGradeDistribution = computed(() =>
             class="h-3 rounded-full transition-all duration-700"
             :class="g.color"
             :style="{
-              width: `${(g.count / props.availability.totalAvailable) * 100}%`,
+              width: `${props.availability.totalAvailable > 0 ? (g.count / props.availability.totalAvailable) * 100 : 0}%`,
             }"
           ></div>
         </div>

--- a/src/features/admin/components/dashboard/DeveloperAvailability.vue
+++ b/src/features/admin/components/dashboard/DeveloperAvailability.vue
@@ -1,0 +1,84 @@
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+  availability: {
+    type: Object,
+    required: true,
+  },
+});
+
+const gradeColorMap = {
+  S: "bg-gradient-to-r from-yellow-300 to-yellow-500",
+  A: "bg-gradient-to-r from-green-300 to-green-500",
+  B: "bg-gradient-to-r from-blue-300 to-blue-500",
+  C: "bg-gradient-to-r from-purple-300 to-purple-500",
+  D: "bg-gradient-to-r from-gray-300 to-gray-500",
+};
+
+const enrichedGradeDistribution = computed(() =>
+  props.availability.gradeDistribution.map((g) => ({
+    ...g,
+    color: gradeColorMap[g.grade] || "bg-gray-400",
+  })),
+);
+</script>
+
+<template>
+  <div
+    class="p-6 bg-white rounded-xl shadow-md border border-gray-200 flex flex-col"
+  >
+    <h2 class="text-lg font-bold text-gray-800 mb-4">
+      🚀 투입 가능 개발자 요약
+    </h2>
+
+    <div class="text-sm text-gray-700 mb-3">
+      총 투입 가능 인원:
+      <span class="font-semibold text-gray-900">
+        {{ props.availability.totalAvailable }}명
+      </span>
+    </div>
+
+    <!-- 등급 분포 -->
+    <div class="space-y-3">
+      <div
+        v-for="g in enrichedGradeDistribution"
+        :key="g.grade"
+        class="flex items-center gap-3 group"
+      >
+        <div
+          class="w-6 text-lg font-extrabold text-gray-800 cursor-help"
+          :title="`${g.grade}급: ${g.count}명`"
+        >
+          {{ g.grade }}
+        </div>
+        <div
+          class="flex-1 bg-gray-200 rounded-full h-3 overflow-hidden relative"
+          :title="`${g.grade}급: ${g.count}명`"
+        >
+          <div
+            class="h-3 rounded-full transition-all duration-700"
+            :class="g.color"
+            :style="{
+              width: `${(g.count / props.availability.totalAvailable) * 100}%`,
+            }"
+          ></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 기술스택 -->
+    <div class="mt-6">
+      <h3 class="text-sm font-semibold text-gray-800 mb-2">💻 가용 기술스택</h3>
+      <div class="flex flex-wrap gap-2">
+        <span
+          v-for="stack in props.availability.availableStacks.slice(0, 20)"
+          :key="stack"
+          class="px-3 py-1 text-xs font-medium bg-gray-100 text-gray-800 rounded-full shadow-sm hover:shadow transition"
+        >
+          {{ stack }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/features/admin/components/dashboard/DeveloperRankingSlider.vue
+++ b/src/features/admin/components/dashboard/DeveloperRankingSlider.vue
@@ -1,0 +1,101 @@
+<script setup>
+import { ref } from "vue";
+
+// ✅ props로 상위 개발자 리스트를 전달받음
+const props = defineProps({
+  topDevelopers: {
+    type: Array,
+    required: true,
+  },
+});
+
+const scrollRef = ref(null);
+
+const scrollLeft = () => {
+  scrollRef.value.scrollBy({ left: -300, behavior: "smooth" });
+};
+
+const scrollRight = () => {
+  scrollRef.value.scrollBy({ left: 300, behavior: "smooth" });
+};
+</script>
+
+<template>
+  <div class="relative w-full">
+    <h2 class="text-lg font-bold text-gray-800 mb-4">🏆 TOP 10 개발자</h2>
+
+    <!-- 슬라이더 영역 -->
+    <div class="relative overflow-hidden">
+      <div
+        ref="scrollRef"
+        class="flex gap-4 overflow-x-auto pb-2 scroll-smooth no-scrollbar"
+      >
+        <div
+          v-for="dev in props.topDevelopers"
+          :key="dev.id"
+          class="flex-shrink-0 w-[220px] bg-white shadow-md rounded-xl p-4 border border-gray-100 hover:shadow-lg transition-all"
+        >
+          <div class="flex flex-col items-center text-center">
+            <img
+              :src="
+                dev.profileUrl ||
+                `https://api.dicebear.com/9.x/notionists/svg?seed=` + dev.id
+              "
+              alt="Profile"
+              class="w-20 h-20 rounded-full object-cover mb-3 border-2 border-primary"
+            />
+            <h3 class="font-semibold text-gray-800 text-base mb-1">
+              {{ dev.name }}
+            </h3>
+            <span
+              class="text-sm font-medium text-white px-2 py-0.5 rounded-full mb-2"
+              :class="{
+                'bg-yellow-500': dev.grade === 'S',
+                'bg-blue-500': dev.grade === 'A',
+                'bg-green-500': dev.grade === 'B',
+                'bg-gray-500': dev.grade === 'C' || dev.grade === 'D',
+              }"
+            >
+              {{ dev.grade }} 등급
+            </span>
+            <p class="text-xs text-gray-500 mb-2">
+              <span class="font-bold">{{
+                Number(dev.productivity).toFixed(1)
+              }}</span>
+              점
+            </p>
+            <div class="flex flex-wrap justify-center items-center gap-2 mt-2">
+              <span
+                v-for="stack in dev.techStacks.slice(0, 3)"
+                :key="stack"
+                class="text-[11px] font-medium text-white bg-support-stack px-2 py-0.5 rounded-full"
+              >
+                {{ stack }}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 좌우 버튼 -->
+      <button
+        @click="scrollLeft"
+        class="absolute top-1/2 -translate-y-1/2 left-0 z-10 bg-white shadow p-2 rounded-full hover:bg-gray-100"
+      >
+        ◀
+      </button>
+      <button
+        @click="scrollRight"
+        class="absolute top-1/2 -translate-y-1/2 right-0 z-10 bg-white shadow p-2 rounded-full hover:bg-gray-100"
+      >
+        ▶
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+</style>

--- a/src/features/admin/components/dashboard/FreelancerTopList.vue
+++ b/src/features/admin/components/dashboard/FreelancerTopList.vue
@@ -29,7 +29,7 @@ const props = defineProps({
             <p class="font-semibold text-gray-800">
               {{ freelancer.name }}
               <span class="text-sm text-gray-500">
-                ({{ freelancer.career_years }}년차)
+                ({{ freelancer.careerYears }}년차)
               </span>
             </p>
           </div>

--- a/src/features/admin/components/dashboard/FreelancerTopList.vue
+++ b/src/features/admin/components/dashboard/FreelancerTopList.vue
@@ -1,0 +1,51 @@
+<script setup>
+// ✅ props로 프리랜서 리스트를 전달받음
+const props = defineProps({
+  freelancers: {
+    type: Array,
+    required: true,
+  },
+});
+</script>
+
+<template>
+  <div
+    class="p-6 bg-white rounded-xl shadow-md border border-gray-200 flex flex-col"
+  >
+    <h2 class="text-lg font-bold text-gray-800 mb-4">👨‍💻 프리랜서 TOP 5</h2>
+    <ul class="space-y-3">
+      <li
+        v-for="freelancer in props.freelancers"
+        :key="freelancer.id"
+        class="flex justify-between items-center bg-gray-50 p-3 rounded-lg hover:bg-gray-100 transition"
+      >
+        <div class="flex items-center gap-3">
+          <img
+            :src="freelancer.profileUrl"
+            alt="Profile"
+            class="w-10 h-10 rounded-full object-cover"
+          />
+          <div>
+            <p class="font-semibold text-gray-800">
+              {{ freelancer.name }}
+              <span class="text-sm text-gray-500">
+                ({{ freelancer.career_years }}년차)
+              </span>
+            </p>
+          </div>
+        </div>
+        <div
+          class="text-sm font-semibold px-2 py-1 rounded-full text-white"
+          :class="{
+            'bg-yellow-500': freelancer.grade === 'S',
+            'bg-blue-500': freelancer.grade === 'A',
+            'bg-green-500': freelancer.grade === 'B',
+            'bg-gray-500': freelancer.grade === 'C' || freelancer.grade === 'D',
+          }"
+        >
+          {{ freelancer.grade }}
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/src/features/admin/components/dashboard/NotificationPanel.vue
+++ b/src/features/admin/components/dashboard/NotificationPanel.vue
@@ -1,0 +1,85 @@
+<script setup>
+import { ref } from "vue";
+
+const myNotifications = ref([
+  {
+    id: 1,
+    title: "새 프로젝트가 배정되었습니다",
+    content: "‘AI 분석 시스템 고도화’에 배정됨",
+    time: "2시간 전",
+  },
+  {
+    id: 2,
+    title: "스쿼드 구성이 완료되었습니다",
+    content: "‘빅데이터 구축 사업’ 스쿼드 확정",
+    time: "어제",
+  },
+]);
+
+const allNotifications = ref([
+  {
+    id: 1,
+    title: "서버 점검 예정",
+    content: "이번 주 토요일 오전 2시~4시 정기 점검",
+    time: "1일 전",
+  },
+  {
+    id: 2,
+    title: "신규 프리랜서 등록",
+    content: "홍길동 프리랜서 등록됨",
+    time: "3일 전",
+  },
+]);
+</script>
+
+<template>
+  <div class="flex gap-8 w-full">
+    <!-- 내 알림 -->
+    <div
+      class="flex-1 p-6 rounded-xl shadow-lg transition-all bg-gradient-to-br from-[#e3f2fd] to-[#f0f8ff] border border-[#bbdefb]"
+    >
+      <h3 class="text-[18px] font-bold mb-5 text-[#333]">📥 내 알림</h3>
+      <ul class="space-y-4">
+        <li
+          v-for="item in myNotifications"
+          :key="item.id"
+          class="bg-white/90 rounded-lg px-5 py-4 border-l-4 border-[#90caf9] shadow-sm hover:-translate-y-0.5 hover:bg-[#f4f6f8] transition-all"
+        >
+          <div class="font-semibold text-[15px] mb-1 text-[#222]">
+            {{ item.title }}
+          </div>
+          <div class="text-[14px] text-[#555] mb-1">
+            {{ item.content }}
+          </div>
+          <div class="text-[12px] text-[#999] text-right">
+            {{ item.time }}
+          </div>
+        </li>
+      </ul>
+    </div>
+
+    <!-- 전체 알림 -->
+    <div
+      class="flex-1 p-6 rounded-xl shadow-lg transition-all bg-gradient-to-br from-[#f3e5f5] to-[#f8f4fc] border border-[#ce93d8]"
+    >
+      <h3 class="text-[18px] font-bold mb-5 text-[#333]">📢 전체 알림</h3>
+      <ul class="space-y-4">
+        <li
+          v-for="item in allNotifications"
+          :key="item.id"
+          class="bg-white/90 rounded-lg px-5 py-4 border-l-4 border-[#ba68c8] shadow-sm hover:-translate-y-0.5 hover:bg-[#f4f6f8] transition-all"
+        >
+          <div class="font-semibold text-[15px] mb-1 text-[#222]">
+            {{ item.title }}
+          </div>
+          <div class="text-[14px] text-[#555] mb-1">
+            {{ item.content }}
+          </div>
+          <div class="text-[12px] text-[#999] text-right">
+            {{ item.time }}
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>

--- a/src/features/admin/components/dashboard/NotificationPanel.vue
+++ b/src/features/admin/components/dashboard/NotificationPanel.vue
@@ -36,7 +36,7 @@ const allNotifications = ref([
   <div class="flex gap-8 w-full">
     <!-- 내 알림 -->
     <div
-      class="flex-1 p-6 rounded-xl shadow-lg transition-all bg-gradient-to-br from-[#e3f2fd] to-[#f0f8ff] border border-[#bbdefb]"
+      class="flex-1 p-6 rounded-xl shadow-lg transition-all bg-gradient-to-br from-blue-50 to-blue-100 border border-blue-200"
     >
       <h3 class="text-[18px] font-bold mb-5 text-[#333]">📥 내 알림</h3>
       <ul class="space-y-4">

--- a/src/features/admin/components/dashboard/ProjectStatusPanel.vue
+++ b/src/features/admin/components/dashboard/ProjectStatusPanel.vue
@@ -2,7 +2,6 @@
 import { useRouter } from "vue-router";
 import { computed } from "vue";
 
-// ✅ props 정의
 const props = defineProps({
   pendingProjects: {
     type: Array,
@@ -15,20 +14,26 @@ const props = defineProps({
 });
 
 const router = useRouter();
-const now = new Date();
 
-const formattedRoles = (roles) =>
-  Object.entries(roles)
+const today = computed(() => new Date().toLocaleDateString("ko-KR"));
+
+const formattedRoles = (roles) => {
+  if (!roles || Object.keys(roles).length === 0) return "직무 정보 없음";
+  return Object.entries(roles)
     .map(([role, count]) => `${role} ${count}명`)
     .join(" / ");
+};
 
 const remainingDays = (startDate) => {
+  const now = new Date();
   const date = new Date(startDate);
   const diff = (date - now) / (1000 * 60 * 60 * 24);
-  return `${Math.ceil(diff)}일 남음`;
+  const daysLeft = Math.ceil(diff);
+  return daysLeft >= 0 ? `${daysLeft}일 남음` : "기간 초과";
 };
 
 const elapsedTime = (startTime) => {
+  const now = new Date();
   const start = new Date(startTime);
   const diffMs = now - start;
   const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
@@ -50,13 +55,13 @@ const goToSquad = (projectCode) => {
       <div class="flex justify-between items-center mb-5">
         <h2 class="text-lg font-bold text-gray-800">마감 임박 프로젝트</h2>
         <span class="text-sm text-primary font-medium">
-          기준: {{ new Date().toLocaleDateString("ko-KR") }}
+          기준: {{ today }}
         </span>
       </div>
 
       <ul class="space-y-4">
         <li
-          v-for="project in props.pendingProjects"
+          v-for="project in pendingProjects"
           :key="project.projectCode"
           class="relative group border-l-4 border-primary pl-4 py-4 bg-gray-50 rounded-md overflow-hidden transition-shadow hover:shadow-lg"
         >
@@ -69,9 +74,7 @@ const goToSquad = (projectCode) => {
                 remainingDays(project.startDate)
               }}</span>
             </div>
-            <p class="text-sm text-gray-600 mb-1">
-              {{ project.description }}
-            </p>
+            <p class="text-sm text-gray-600 mb-1">{{ project.description }}</p>
             <p class="text-sm text-gray-500">
               직무: {{ formattedRoles(project.roles) }}
             </p>
@@ -103,8 +106,8 @@ const goToSquad = (projectCode) => {
       <h2 class="text-lg font-bold text-gray-800 mb-5">분석 중 프로젝트</h2>
       <ul class="space-y-4">
         <li
-          v-for="project in props.analyzingProjects"
-          :key="project.id"
+          v-for="project in analyzingProjects"
+          :key="project.projectCode"
           class="p-4 bg-gray-50 rounded-md border-l-4 border-blue-400"
         >
           <div class="flex justify-between items-center mb-1">

--- a/src/features/admin/components/dashboard/ProjectStatusPanel.vue
+++ b/src/features/admin/components/dashboard/ProjectStatusPanel.vue
@@ -37,7 +37,7 @@ const elapsedTime = (startTime) => {
 };
 
 const goToSquad = (projectCode) => {
-  router.push(`/squads/${projectCode}`);
+  router.push(`/squads?projectId=${projectCode}`);
 };
 </script>
 

--- a/src/features/admin/components/dashboard/ProjectStatusPanel.vue
+++ b/src/features/admin/components/dashboard/ProjectStatusPanel.vue
@@ -1,0 +1,122 @@
+<script setup>
+import { useRouter } from "vue-router";
+import { computed } from "vue";
+
+// ✅ props 정의
+const props = defineProps({
+  pendingProjects: {
+    type: Array,
+    required: true,
+  },
+  analyzingProjects: {
+    type: Array,
+    required: true,
+  },
+});
+
+const router = useRouter();
+const now = new Date();
+
+const formattedRoles = (roles) =>
+  Object.entries(roles)
+    .map(([role, count]) => `${role} ${count}명`)
+    .join(" / ");
+
+const remainingDays = (startDate) => {
+  const date = new Date(startDate);
+  const diff = (date - now) / (1000 * 60 * 60 * 24);
+  return `${Math.ceil(diff)}일 남음`;
+};
+
+const elapsedTime = (startTime) => {
+  const start = new Date(startTime);
+  const diffMs = now - start;
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffMinutes = Math.floor((diffMs / (1000 * 60)) % 60);
+  return `${diffHours}시간 ${diffMinutes}분 경과`;
+};
+
+const goToSquad = (projectCode) => {
+  router.push(`/squads/${projectCode}`);
+};
+</script>
+
+<template>
+  <div class="flex w-full gap-6">
+    <!-- 마감 임박 프로젝트 -->
+    <div
+      class="flex-[2] p-6 bg-white rounded-xl shadow-md border border-gray-200"
+    >
+      <div class="flex justify-between items-center mb-5">
+        <h2 class="text-lg font-bold text-gray-800">마감 임박 프로젝트</h2>
+        <span class="text-sm text-primary font-medium">
+          기준: {{ new Date().toLocaleDateString("ko-KR") }}
+        </span>
+      </div>
+
+      <ul class="space-y-4">
+        <li
+          v-for="project in props.pendingProjects"
+          :key="project.projectCode"
+          class="relative group border-l-4 border-primary pl-4 py-4 bg-gray-50 rounded-md overflow-hidden transition-shadow hover:shadow-lg"
+        >
+          <div class="transition-all group-hover:translate-x-[-4px]">
+            <div class="flex justify-between items-center mb-1">
+              <h3 class="font-semibold text-base text-gray-800">
+                {{ project.title }}
+              </h3>
+              <span class="text-xs text-secondary">{{
+                remainingDays(project.startDate)
+              }}</span>
+            </div>
+            <p class="text-sm text-gray-600 mb-1">
+              {{ project.description }}
+            </p>
+            <p class="text-sm text-gray-500">
+              직무: {{ formattedRoles(project.roles) }}
+            </p>
+            <div class="flex justify-between mt-1 text-xs text-gray-400">
+              <span>예산: {{ project.budget.toLocaleString() }}만원</span>
+              <span>도메인: {{ project.domainName }}</span>
+            </div>
+          </div>
+
+          <!-- 슬라이드 버튼 -->
+          <div
+            class="absolute top-1/2 right-4 transform -translate-y-1/2 translate-x-full group-hover:translate-x-0 transition-all duration-300"
+          >
+            <button
+              @click="goToSquad(project.projectCode)"
+              class="px-4 py-1 text-sm font-semibold rounded-md bg-primary text-white shadow hover:bg-primary-dark transition"
+            >
+              스쿼드 구성하기 →
+            </button>
+          </div>
+        </li>
+      </ul>
+    </div>
+
+    <!-- 분석 중 프로젝트 -->
+    <div
+      class="flex-1 p-6 bg-white rounded-xl shadow-md border border-gray-200"
+    >
+      <h2 class="text-lg font-bold text-gray-800 mb-5">분석 중 프로젝트</h2>
+      <ul class="space-y-4">
+        <li
+          v-for="project in props.analyzingProjects"
+          :key="project.id"
+          class="p-4 bg-gray-50 rounded-md border-l-4 border-blue-400"
+        >
+          <div class="flex justify-between items-center mb-1">
+            <h3 class="font-semibold text-base text-gray-800">
+              {{ project.name }}
+            </h3>
+            <span class="text-xs text-blue-500">{{
+              elapsedTime(project.analysisStartTime)
+            }}</span>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>

--- a/src/features/admin/components/dashboard/TechStackDemand.vue
+++ b/src/features/admin/components/dashboard/TechStackDemand.vue
@@ -1,0 +1,61 @@
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+  stacks: {
+    type: Array,
+    required: true,
+  },
+});
+
+// 최소/최대 count 추출
+const minCount = computed(() => Math.min(...props.stacks.map((s) => s.count)));
+const maxCount = computed(() => Math.max(...props.stacks.map((s) => s.count)));
+
+// 정규화된 스택 리스트
+const normalizedStacks = computed(() =>
+  props.stacks.map((stack) => {
+    const min = minCount.value;
+    const max = maxCount.value;
+    const normalized =
+      max === min
+        ? 1 // 모든 값이 같을 경우 100% 너비
+        : (stack.count - min) / (max - min);
+    const widthPercent = 30 + normalized * 70; // 30% ~ 100% 범위로 보정
+    return {
+      ...stack,
+      widthPercent,
+    };
+  }),
+);
+</script>
+
+<template>
+  <div
+    class="p-6 bg-white rounded-xl shadow-md border border-gray-200 flex flex-col"
+  >
+    <h3 class="text-[16px] font-bold text-[#222] mb-4">
+      📊 기술스택 수요 TOP 5
+    </h3>
+
+    <ul class="space-y-3">
+      <li
+        v-for="stack in normalizedStacks"
+        :key="stack.name"
+        class="relative flex flex-col gap-1 text-sm text-gray-800 bg-gray-100 rounded-lg overflow-hidden px-4 py-2"
+      >
+        <!-- 배경 막대 (정규화된 너비) -->
+        <div
+          class="absolute top-0 left-0 h-full bg-primary z-0 transition-all rounded-full"
+          :style="{ width: `${stack.widthPercent}%` }"
+        ></div>
+
+        <!-- 텍스트 컨텐츠 -->
+        <div class="flex justify-between items-center relative z-10">
+          <span class="font-semibold text-white">{{ stack.name }}</span>
+          <span class="text-black font-light">{{ stack.count }}회</span>
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/src/features/admin/router.js
+++ b/src/features/admin/router.js
@@ -1,5 +1,14 @@
 export const adminRoutes = [
   {
+    path: "/",
+    name: "AdminDashboardView",
+    component: () => import("./views/AdminDashboardView.vue"),
+    meta: {
+      requiresAuth: true,
+      roles: ["ADMIN"],
+    },
+  },
+  {
     path: "/admin/domains",
     name: "AdminDomainsView",
     component: () => import("./views/AdminDomainsView.vue"),

--- a/src/features/admin/views/AdminDashBoardView.vue
+++ b/src/features/admin/views/AdminDashBoardView.vue
@@ -1,0 +1,78 @@
+<script setup>
+import { ref, onMounted } from "vue";
+
+import NotificationPanel from "../components/dashboard/NotificationPanel.vue";
+import ProjectStatusPanel from "../components/dashboard/ProjectStatusPanel.vue";
+import DeveloperRankingSlider from "../components/dashboard/DeveloperRankingSlider.vue";
+import FreelancerTopList from "../components/dashboard/FreelancerTopList.vue";
+import DeveloperAvailability from "../components/dashboard/DeveloperAvailability.vue";
+import TechStackDemand from "../components/dashboard/TechStackDemand.vue";
+import { getAdminMainDashboard } from "@/api/admin.js";
+import { showErrorToast } from "@/utills/toast.js";
+
+const dashboardData = ref(null);
+
+onMounted(async () => {
+  try {
+    const res = await getAdminMainDashboard();
+    dashboardData.value = res.data.data;
+    console.log(dashboardData.value);
+  } catch (error) {
+    showErrorToast("대시보드 요약 정보 로딩에 실패했습니다");
+  }
+});
+</script>
+
+<template>
+  <div class="admin-dashboard">
+    <div class="dashboard-row">
+      <NotificationPanel />
+    </div>
+
+    <div class="dashboard-row">
+      <ProjectStatusPanel
+        :pending-projects="dashboardData?.pendingProjects || []"
+        :analyzing-projects="dashboardData?.analyzingProjects || []"
+      />
+    </div>
+
+    <div class="dashboard-row">
+      <DeveloperRankingSlider
+        :top-developers="dashboardData?.topDevelopers || []"
+      />
+    </div>
+
+    <div class="dashboard-row last-row">
+      <FreelancerTopList :freelancers="dashboardData?.freelancerTop5 || []" />
+      <DeveloperAvailability
+        v-if="dashboardData?.developerAvailability"
+        :availability="dashboardData.developerAvailability"
+      />
+      <TechStackDemand :stacks="dashboardData?.techStackDemand || []" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.admin-dashboard {
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.dashboard-row {
+  display: flex;
+  gap: 30px;
+}
+
+.last-row {
+  justify-content: space-between;
+}
+
+.last-row > * {
+  flex: 1;
+}
+</style>

--- a/src/features/admin/views/AdminDashBoardView.vue
+++ b/src/features/admin/views/AdminDashBoardView.vue
@@ -16,7 +16,6 @@ onMounted(async () => {
   try {
     const res = await getAdminMainDashboard();
     dashboardData.value = res.data.data;
-    console.log(dashboardData.value);
   } catch (error) {
     showErrorToast("대시보드 요약 정보 로딩에 실패했습니다");
   }

--- a/src/features/project/components/ReplacementDeveloperSearch.vue
+++ b/src/features/project/components/ReplacementDeveloperSearch.vue
@@ -115,9 +115,10 @@ function renderSummary() {
 }
 
 function handleReplace(dev) {
+  console.log(dev);
   emit("replace", {
     oldMemberId: props.leavingMember.employeeId,
-    newMemberId: dev.value.employeeId,
+    newMemberId: dev.id,
   });
 }
 

--- a/src/features/project/components/ReplacementDeveloperSearch.vue
+++ b/src/features/project/components/ReplacementDeveloperSearch.vue
@@ -115,7 +115,10 @@ function renderSummary() {
 }
 
 function handleReplace(dev) {
-  emit("replace", dev); // 단순하게 선택한 개발자 객체 전달
+  emit("replace", {
+    oldMemberId: props.leavingMember.employeeId,
+    newMemberId: dev.value.employeeId,
+  });
 }
 
 onMounted(() => {

--- a/src/features/project/components/ReplacementDeveloperSearch.vue
+++ b/src/features/project/components/ReplacementDeveloperSearch.vue
@@ -1,0 +1,284 @@
+<script setup>
+import { ref, onMounted, onBeforeUnmount } from "vue";
+import FilterModal from "@/features/squad/components/modal/FilterModal.vue";
+import SortModal from "@/features/squad/components/modal/SortModal.vue";
+import BasePagination from "@/components/Pagination.vue";
+import { searchSquadDevelopers } from "@/api/squad.js";
+
+const props = defineProps({
+  project: Object,
+  leavingMember: Object,
+});
+const emit = defineEmits(["replace"]);
+
+const searchQuery = ref("");
+const developers = ref([]);
+const currentPage = ref(1);
+const totalPages = ref(1);
+
+const isFocused = ref(false);
+const showFilter = ref(false);
+const showSort = ref(false);
+
+const selectedFilters = ref({
+  techStacks: [],
+  grades: [],
+  statuses: [],
+  freelancer: null,
+  sortBy: "",
+  sortOrder: "",
+});
+
+async function handleSearch(page = 1) {
+  const payload = {
+    keyword: searchQuery.value,
+    status: selectedFilters.value.statuses[0] || null,
+    grades: selectedFilters.value.grades,
+    stacks: selectedFilters.value.techStacks,
+    memberRoles: selectedFilters.value.freelancer
+      ? [selectedFilters.value.freelancer]
+      : [],
+    sortBy: selectedFilters.value.sortBy || "grade",
+    sortDir: selectedFilters.value.sortOrder || "asc",
+    page: page - 1,
+    size: 10,
+  };
+
+  try {
+    const result = await searchSquadDevelopers(payload);
+    developers.value = result.content.map((dev) => ({
+      id: dev.employeeId,
+      name: dev.name,
+      grade: dev.grade,
+      status: dev.status === "AVAILABLE" ? "대기중" : "투입중",
+      techStack: [dev.topTechStackName],
+    }));
+
+    currentPage.value = result.currentPage + 1;
+    totalPages.value = result.totalPages;
+  } catch (e) {
+    developers.value = [];
+    currentPage.value = 1;
+    totalPages.value = 1;
+  }
+}
+
+function removeTechStack(stack) {
+  selectedFilters.value.techStacks = selectedFilters.value.techStacks.filter(
+    (s) => s !== stack,
+  );
+}
+
+function addTechStack(stack) {
+  if (!selectedFilters.value.techStacks.includes(stack)) {
+    selectedFilters.value.techStacks.push(stack);
+  }
+}
+
+function toggleFilter() {
+  showSort.value = false;
+  showFilter.value = !showFilter.value;
+}
+function toggleSort() {
+  showFilter.value = false;
+  showSort.value = !showSort.value;
+}
+
+function handleDocumentClick(e) {
+  const filterModal = document.getElementById("filterModal");
+  const sortModal = document.getElementById("sortModal");
+  if (filterModal && !filterModal.contains(e.target)) {
+    showFilter.value = false;
+  }
+  if (sortModal && !sortModal.contains(e.target)) {
+    showSort.value = false;
+  }
+}
+
+function renderSummary() {
+  const parts = [];
+
+  if (selectedFilters.value.techStacks.length)
+    parts.push(selectedFilters.value.techStacks.join(", "));
+  if (selectedFilters.value.grades.length)
+    parts.push(selectedFilters.value.grades.join(", "));
+  if (selectedFilters.value.statuses.length)
+    parts.push(selectedFilters.value.statuses.join(", "));
+  if (selectedFilters.value.freelancer)
+    parts.push(selectedFilters.value.freelancer);
+  if (selectedFilters.value.sortBy || selectedFilters.value.sortOrder)
+    parts.push(
+      `${selectedFilters.value.sortBy}-${selectedFilters.value.sortOrder}`,
+    );
+
+  return parts.join(" / ");
+}
+
+function handleReplace(dev) {
+  emit("replace", dev); // 단순하게 선택한 개발자 객체 전달
+}
+
+onMounted(() => {
+  document.addEventListener("click", handleDocumentClick);
+  handleSearch();
+});
+onBeforeUnmount(() => {
+  document.removeEventListener("click", handleDocumentClick);
+});
+</script>
+
+<template>
+  <div>
+    <!-- 검색바 -->
+    <div class="search-bar" :class="{ focused: isFocused }">
+      <input
+        v-model="searchQuery"
+        type="text"
+        placeholder="개발자를 검색해주세요"
+        class="search-input"
+        @focus="isFocused = true"
+        @blur="isFocused = false"
+        @keyup.enter="handleSearch"
+      />
+
+      <div class="relative">
+        <button class="btn-icon" @click.stop="toggleFilter">
+          <i class="fa-solid fa-filter"></i>
+        </button>
+        <FilterModal
+          v-if="showFilter"
+          :selectedFilters="selectedFilters"
+          @removeTechStack="removeTechStack"
+          @addTechStack="addTechStack"
+        />
+      </div>
+
+      <div class="relative">
+        <button class="btn-icon" @click.stop="toggleSort">
+          <i class="fa-solid fa-align-center"></i>
+        </button>
+        <SortModal v-if="showSort" :selectedFilters="selectedFilters" />
+      </div>
+
+      <button class="btn-icon" @click="handleSearch">
+        <i class="fa-solid fa-magnifying-glass"></i>
+      </button>
+    </div>
+
+    <div class="filter-summary">
+      <div class="overflow-hidden whitespace-nowrap text-ellipsis">
+        {{ renderSummary() }}
+      </div>
+    </div>
+
+    <div class="table-wrapper">
+      <template v-if="developers.length > 0">
+        <table class="dev-table">
+          <thead>
+            <tr>
+              <th>번호</th>
+              <th>개발자명</th>
+              <th>등급</th>
+              <th>상태</th>
+              <th>기술스택</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="(dev, index) in developers"
+              :key="dev.id"
+              class="hover:bg-gray-50 cursor-pointer"
+            >
+              <td class="text-center">{{ index + 1 }}</td>
+              <td class="text-center">{{ dev.name }}</td>
+              <td class="text-center font-bold">{{ dev.grade }}</td>
+              <td class="text-center">
+                <span class="status-badge">{{ dev.status }}</span>
+              </td>
+              <td class="text-center">
+                <div class="stack-list">
+                  <span
+                    v-for="stack in dev.techStack"
+                    :key="stack"
+                    class="stack-badge"
+                  >
+                    {{ stack }}
+                  </span>
+                </div>
+              </td>
+              <td class="text-center">
+                <button class="btn-add" @click="handleReplace(dev)">
+                  교체
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </template>
+      <template v-else>
+        <div class="empty-message">검색한 개발자가 없습니다</div>
+      </template>
+    </div>
+
+    <div class="flex justify-center">
+      <BasePagination
+        :current-page="currentPage"
+        :total-pages="totalPages"
+        @change="handleSearch"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.search-bar {
+  @apply flex items-center gap-2 mb-4 px-3 py-2 border border-gray-300 rounded transition relative;
+}
+.search-bar.focused {
+  @apply border-primary ring-2 ring-primary/30;
+}
+.search-input {
+  @apply flex-1 outline-none border-none bg-transparent;
+}
+.btn-icon {
+  @apply px-4 py-3 text-sm hover:bg-gray-100 rounded;
+}
+.filter-summary {
+  @apply mb-3 text-sm text-gray-600 max-w-full overflow-hidden;
+}
+.table-wrapper {
+  @apply h-[500px] overflow-y-auto border border-gray-200 relative mb-4;
+}
+.dev-table {
+  @apply w-full border-collapse text-sm text-center;
+}
+.dev-table thead th {
+  @apply bg-gray-100 text-gray-800 py-2 border-b border-gray-300;
+}
+.dev-table tbody td {
+  @apply py-2 border-b border-gray-100;
+}
+.status-badge {
+  @apply inline-block px-2 py-1 text-xs bg-yellow-200 text-yellow-800 rounded;
+}
+.stack-list {
+  @apply flex justify-center gap-1 flex-wrap;
+}
+.stack-badge {
+  @apply px-2 py-1 bg-gray-200 text-xs rounded;
+}
+.btn-add {
+  @apply px-5 py-2 bg-white text-primary border border-primary shadow-sm rounded text-sm font-bold hover:bg-gray-50 transition;
+}
+
+.pagination button {
+  @apply px-2 py-1 text-sm border border-gray-300 rounded hover:bg-gray-100;
+}
+.pagination .active {
+  @apply bg-primary text-white;
+}
+.empty-message {
+  @apply absolute inset-0 flex items-center justify-center text-gray-400;
+}
+</style>

--- a/src/features/project/components/ReplacementPanel.vue
+++ b/src/features/project/components/ReplacementPanel.vue
@@ -1,0 +1,121 @@
+<script setup>
+import { computed, ref } from "vue";
+import ReplacementDeveloperSearch from "@/features/project/components/ReplacementDeveloperSearch.vue";
+import ReplacementSearchPanel from "@/features/project/components/ReplacementSearchPanel.vue";
+import AiLoadingOverlay from "@/components/AiLoadingOverlay.vue"; // 필요시 위치 조정
+
+const props = defineProps({
+  project: Object,
+  leavingMember: Object,
+});
+
+const visible = computed(() => props.project && props.leavingMember);
+defineEmits(["close", "replace"]);
+
+const activeTab = ref("manual");
+const isLoading = ref(false);
+const showAISection = ref(false);
+
+function switchToAI() {
+  activeTab.value = "ai";
+  isLoading.value = false;
+  showAISection.value = true;
+
+  // setTimeout(() => {
+  //   isLoading.value = false;
+  //   showAISection.value = true;
+  // }, 3000);
+}
+</script>
+
+<template>
+  <transition name="slide">
+    <div v-if="visible" class="fixed inset-0 z-50">
+      <div class="absolute inset-0 opacity-30" @click="$emit('close')"></div>
+
+      <div
+        class="absolute top-0 right-0 w-[650px] h-full bg-white border-l shadow-xl z-50 p-6 overflow-y-auto"
+        @click.stop
+      >
+        <h2 class="text-xl font-bold mb-2">인재 대체</h2>
+        <p class="text-sm text-gray-600 mb-4">
+          <strong>{{ leavingMember.name }}</strong> 님을 대체할 인재를
+          선택하세요.
+        </p>
+
+        <!-- 탭 -->
+        <div class="flex gap-3 mb-4">
+          <button
+            :class="['tab-btn', activeTab === 'manual' ? 'active' : '']"
+            @click="activeTab = 'manual'"
+          >
+            직접 조회
+          </button>
+          <button
+            :class="['tab-btn', activeTab === 'ai' ? 'active' : '']"
+            @click="switchToAI"
+          >
+            AI 추천
+          </button>
+        </div>
+
+        <ReplacementDeveloperSearch
+          v-if="activeTab === 'manual'"
+          :project="project"
+          :leaving-member="leavingMember"
+          @replace="(payload) => $emit('replace', payload)"
+        />
+
+        <AiLoadingOverlay
+          :visible="isLoading"
+          message="AI 분석 기반 <strong>추천 인재 탐색</strong>이 진행중입니다..."
+        />
+
+        <transition name="fade">
+          <ReplacementSearchPanel
+            v-if="activeTab === 'ai' && showAISection"
+            :project="project"
+            :leaving-member="leavingMember"
+            @replace="(payload) => $emit('replace', payload)"
+          />
+        </transition>
+
+        <div class="mt-6 flex justify-end">
+          <button @click="$emit('close')" class="text-sm text-gray-500">
+            닫기
+          </button>
+        </div>
+      </div>
+    </div>
+  </transition>
+</template>
+
+<style scoped>
+.slide-enter-active,
+.slide-leave-active {
+  transition: all 0.3s ease-in-out;
+}
+.slide-enter-from {
+  transform: translateX(100%);
+  opacity: 0;
+}
+.slide-enter-to {
+  transform: translateX(0);
+  opacity: 1;
+}
+.slide-leave-from {
+  transform: translateX(0);
+  opacity: 1;
+}
+.slide-leave-to {
+  transform: translateX(100%);
+  opacity: 0;
+}
+
+.tab-btn {
+  @apply px-4 py-2 border rounded text-sm font-medium;
+}
+.tab-btn.active {
+  @apply bg-primary text-white border-primary;
+}
+</style>

--- a/src/features/project/components/ReplacementPanel.vue
+++ b/src/features/project/components/ReplacementPanel.vue
@@ -18,13 +18,13 @@ const showAISection = ref(false);
 
 function switchToAI() {
   activeTab.value = "ai";
-  isLoading.value = false;
-  showAISection.value = true;
+  isLoading.value = true;
+  showAISection.value = false;
 
   setTimeout(() => {
     isLoading.value = false;
     showAISection.value = true;
-  }, 1000);
+  }, 2000);
 }
 </script>
 

--- a/src/features/project/components/ReplacementPanel.vue
+++ b/src/features/project/components/ReplacementPanel.vue
@@ -21,10 +21,10 @@ function switchToAI() {
   isLoading.value = false;
   showAISection.value = true;
 
-  // setTimeout(() => {
-  //   isLoading.value = false;
-  //   showAISection.value = true;
-  // }, 3000);
+  setTimeout(() => {
+    isLoading.value = false;
+    showAISection.value = true;
+  }, 1000);
 }
 </script>
 

--- a/src/features/project/components/ReplacementSearchPanel.vue
+++ b/src/features/project/components/ReplacementSearchPanel.vue
@@ -1,3 +1,58 @@
+<script setup>
+import { ref, onMounted } from "vue";
+import { replaceRecommendation } from "@/api/project.js";
+import { useRoute } from "vue-router";
+
+const props = defineProps({
+  project: Object,
+  leavingMember: Object,
+});
+
+const emit = defineEmits(["replace"]);
+
+const candidates = ref([]);
+const selected = ref(null);
+const isLoading = ref(true);
+
+const select = (dev) => {
+  selected.value = dev;
+};
+
+const emitReplace = () => {
+  emit("replace", {
+    oldMemberId: props.leavingMember.employeeId,
+    newMemberId: selected.value.id,
+  });
+};
+
+const route = useRoute();
+const projectCode = route.params.projectCode;
+
+onMounted(async () => {
+  try {
+    const response = await replaceRecommendation({
+      projectCode: projectCode,
+      leavingMember: props.leavingMember.employeeId,
+    });
+    candidates.value = response.data.data;
+  } catch (e) {
+    console.error("추천 인재 조회 실패", e);
+  } finally {
+    isLoading.value = false;
+  }
+});
+</script>
+
+<style scoped>
+/* Glow 효과 */
+.glow {
+  box-shadow:
+    0 0 8px rgba(101, 116, 246, 0.6),
+    0 0 12px rgba(101, 116, 246, 0.4),
+    0 0 20px rgba(101, 116, 246, 0.2);
+}
+</style>
+
 <template>
   <div>
     <h3 class="text-sm font-semibold mb-4">최적 인재 추천</h3>
@@ -64,58 +119,3 @@
     </button>
   </div>
 </template>
-
-<script setup>
-import { ref, onMounted } from "vue";
-import { replaceRecommendation } from "@/api/project.js";
-import { useRoute } from "vue-router";
-
-const props = defineProps({
-  project: Object,
-  leavingMember: Object,
-});
-
-const emit = defineEmits(["replace"]);
-
-const candidates = ref([]);
-const selected = ref(null);
-const isLoading = ref(true);
-
-const select = (dev) => {
-  selected.value = dev;
-};
-
-const emitReplace = () => {
-  emit("replace", {
-    oldMember: props.leavingMember,
-    newMember: selected.value,
-  });
-};
-
-const route = useRoute();
-const projectCode = route.params.projectCode;
-
-onMounted(async () => {
-  try {
-    const response = await replaceRecommendation({
-      projectCode: projectCode,
-      leavingMember: props.leavingMember.employeeId,
-    });
-    candidates.value = response.data.data;
-  } catch (e) {
-    console.error("추천 인재 조회 실패", e);
-  } finally {
-    isLoading.value = false;
-  }
-});
-</script>
-
-<style scoped>
-/* Glow 효과 */
-.glow {
-  box-shadow:
-    0 0 8px rgba(101, 116, 246, 0.6),
-    0 0 12px rgba(101, 116, 246, 0.4),
-    0 0 20px rgba(101, 116, 246, 0.2);
-}
-</style>

--- a/src/features/project/components/ReplacementSearchPanel.vue
+++ b/src/features/project/components/ReplacementSearchPanel.vue
@@ -1,0 +1,121 @@
+<template>
+  <div>
+    <h3 class="text-sm font-semibold mb-4">최적 인재 추천</h3>
+
+    <div v-if="isLoading" class="text-gray-500">
+      추천 인재를 불러오는 중입니다...
+    </div>
+    <div v-else-if="candidates.length === 0" class="text-sm text-gray-400">
+      추천 인재가 없습니다.
+    </div>
+
+    <div v-else class="flex flex-col gap-4">
+      <div
+        v-for="(dev, index) in candidates.slice(0, 5)"
+        :key="dev.id"
+        @click="select(dev)"
+        :class="[
+          'p-4 rounded-xl shadow transition-all duration-200 cursor-pointer group border-2',
+          selected?.id === dev.id
+            ? 'border-blue-600 ring-2 ring-blue-200'
+            : 'border-gray-200',
+          index === 0 ? 'shadow-xl glow' : '',
+        ]"
+      >
+        <!-- 이름 -->
+        <div
+          class="text-lg font-bold text-gray-900 mb-3 group-hover:underline tracking-tight"
+        >
+          {{ index + 1 }}위 · {{ dev.name }}
+        </div>
+
+        <!-- 정보 박스 3개 -->
+        <div class="flex gap-3">
+          <div
+            class="flex-1 rounded-md bg-blue-100 text-blue-800 font-semibold text-center py-2 text-sm shadow-inner"
+          >
+            기술점수<br />
+            <span class="text-xl">{{ dev.avgTechScore.toFixed(1) }}</span>
+          </div>
+
+          <div
+            class="flex-1 rounded-md bg-green-100 text-green-800 font-semibold text-center py-2 text-sm shadow-inner"
+          >
+            도메인 경험<br />
+            <span class="text-xl">{{ dev.domainCount }}</span>
+          </div>
+
+          <div
+            class="flex-1 rounded-md text-rose-500 font-semibold text-center py-2 text-sm shadow-inner bg-rose-100"
+          >
+            등급<br />
+            <span class="text-xl">{{ dev.grade }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <button
+      :disabled="!selected"
+      class="mt-6 w-full bg-primary text-white py-2 rounded disabled:opacity-50"
+      @click="emitReplace"
+    >
+      선택한 인재로 대체하기
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from "vue";
+import { replaceRecommendation } from "@/api/project.js";
+import { useRoute } from "vue-router";
+
+const props = defineProps({
+  project: Object,
+  leavingMember: Object,
+});
+
+const emit = defineEmits(["replace"]);
+
+const candidates = ref([]);
+const selected = ref(null);
+const isLoading = ref(true);
+
+const select = (dev) => {
+  selected.value = dev;
+};
+
+const emitReplace = () => {
+  emit("replace", {
+    oldMember: props.leavingMember,
+    newMember: selected.value,
+  });
+};
+
+const route = useRoute();
+const projectCode = route.params.projectCode;
+
+onMounted(async () => {
+  try {
+    const response = await replaceRecommendation({
+      projectCode: projectCode,
+      leavingMember: props.leavingMember.employeeId,
+    });
+    candidates.value = response.data.data;
+  } catch (e) {
+    console.error("추천 인재 조회 실패", e);
+  } finally {
+    isLoading.value = false;
+  }
+});
+</script>
+
+<style scoped>
+/* Glow 효과 */
+.glow {
+  box-shadow:
+    0 0 8px rgba(101, 116, 246, 0.6),
+    0 0 12px rgba(101, 116, 246, 0.4),
+    0 0 20px rgba(101, 116, 246, 0.2);
+}
+</style>

--- a/src/features/project/components/SquadCard.vue
+++ b/src/features/project/components/SquadCard.vue
@@ -2,8 +2,9 @@
   <div
     :class="[
       'flex items-center justify-between px-6 py-4 transition-all duration-200',
-      isLeader === 1
-        ? 'cursor-not-allowed opacity-50 bg-gray-100'
+      approvalStatus !== 'APPROVED' ? 'opacity-50' : 'opacity-100',
+      isLeader === 1 && isReplacementMode
+        ? 'cursor-not-allowed bg-gray-100'
         : selected
           ? 'cursor-pointer bg-yellow-50 border-yellow-400 border-2 rounded-md'
           : isReplacementMode
@@ -22,6 +23,7 @@
       <div>
         <div class="flex items-center gap-1">
           <p class="text-sm font-semibold text-gray-800">{{ name }}</p>
+          <!-- 리더 아이콘 -->
           <svg
             v-if="isLeader === 1"
             xmlns="http://www.w3.org/2000/svg"
@@ -31,14 +33,33 @@
           >
             <path d="M5 16h14v2H5v-2Zm14-8-4 4-3-3-3 3-4-4-1 6h16l-1-6Z" />
           </svg>
+          <!-- 승인 상태 아이콘 -->
+          <svg
+            v-if="approvalStatus === 'APPROVED'"
+            xmlns="http://www.w3.org/2000/svg"
+            class="w-4 h-4 text-green-500"
+            fill="currentColor"
+            viewBox="0 0 20 20"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M16.707 5.293a1 1 0 010 1.414l-8.25 8.25a1 1 0 01-1.414 0l-4.25-4.25a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+              clip-rule="evenodd"
+            />
+          </svg>
         </div>
         <p class="text-xs text-blue-600">{{ role }}</p>
       </div>
     </div>
+    <p class="text-xs text-gray-500 capitalize">
+      {{ statusText }}
+    </p>
   </div>
 </template>
 
 <script setup>
+import { computed } from "vue";
+
 const emit = defineEmits(["click"]);
 
 const props = defineProps({
@@ -54,10 +75,24 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  approvalStatus: {
+    type: String,
+    default: "NOT_REQUESTED",
+  },
 });
 
+const approvalStatusMapping = {
+  NOT_REQUESTED: "요청 전",
+  PENDING: "승인 대기",
+  APPROVED: "승인 완료",
+  REJECTED: "승인 거절",
+};
+
+const statusText = computed(
+  () => approvalStatusMapping[props.approvalStatus] || "알 수 없음",
+);
+
 function handleClick() {
-  // 리더일 경우 클릭 방지
   if (props.isLeader === 1) return;
   emit("click");
 }

--- a/src/features/project/components/SquadCard.vue
+++ b/src/features/project/components/SquadCard.vue
@@ -1,13 +1,16 @@
 <template>
   <div
     :class="[
-      'flex items-center justify-between px-6 py-4 transition-all duration-200 cursor-pointer',
-      selected
-        ? 'bg-yellow-50 border-yellow-400 border-2 rounded-md'
-        : isReplacementMode
-          ? 'hover:bg-yellow-50'
-          : 'bg-[#F7FAFC]',
+      'flex items-center justify-between px-6 py-4 transition-all duration-200',
+      isLeader === 1
+        ? 'cursor-not-allowed opacity-50 bg-gray-100'
+        : selected
+          ? 'cursor-pointer bg-yellow-50 border-yellow-400 border-2 rounded-md'
+          : isReplacementMode
+            ? 'cursor-pointer hover:bg-yellow-50'
+            : 'cursor-pointer bg-[#F7FAFC]',
     ]"
+    @click="handleClick"
   >
     <!-- 프로필 + 이름/직무 -->
     <div class="flex items-center gap-4">
@@ -36,7 +39,9 @@
 </template>
 
 <script setup>
-defineProps({
+const emit = defineEmits(["click"]);
+
+const props = defineProps({
   name: String,
   role: String,
   isLeader: Number,
@@ -50,4 +55,10 @@ defineProps({
     default: false,
   },
 });
+
+function handleClick() {
+  // 리더일 경우 클릭 방지
+  if (props.isLeader === 1) return;
+  emit("click");
+}
 </script>

--- a/src/features/project/components/SquadCard.vue
+++ b/src/features/project/components/SquadCard.vue
@@ -1,5 +1,14 @@
 <template>
-  <div class="flex items-center justify-between px-6 py-4 bg-[#F7FAFC]">
+  <div
+    :class="[
+      'flex items-center justify-between px-6 py-4 transition-all duration-200 cursor-pointer',
+      selected
+        ? 'bg-yellow-50 border-yellow-400 border-2 rounded-md'
+        : isReplacementMode
+          ? 'hover:bg-yellow-50'
+          : 'bg-[#F7FAFC]',
+    ]"
+  >
     <!-- 프로필 + 이름/직무 -->
     <div class="flex items-center gap-4">
       <img
@@ -32,5 +41,13 @@ defineProps({
   role: String,
   isLeader: Number,
   imageUrl: String,
+  selected: {
+    type: Boolean,
+    default: false,
+  },
+  isReplacementMode: {
+    type: Boolean,
+    default: false,
+  },
 });
 </script>

--- a/src/features/project/views/ProjectDetailView.vue
+++ b/src/features/project/views/ProjectDetailView.vue
@@ -32,7 +32,7 @@ onMounted(async () => {
     project.value = response.data.data;
 
     if (project.value?.members?.length > 0) {
-      replacingMember.value = project.value.members[0];
+      replacingMember.value = project.value.members[1];
       console.log(replacingMember.value);
     }
   } catch (error) {
@@ -105,22 +105,22 @@ const handleMemberClick = (member) => {
   }
 };
 
-const handleReplace = async ({ oldMember, newMember }) => {
+const handleReplace = async ({ oldMemberId, newMemberId }) => {
   try {
     await replaceProjectSquad({
       squadCode: project.value.squadCode,
-      oldEmployeeId: oldMember.employeeId,
-      newEmployeeId: newMember.employeeId,
+      oldEmployeeId: oldMemberId,
+      newEmployeeId: newMemberId,
     });
-    showSuccessToast("인재가 성공적으로 대체되었습니다.");
+    showSuccessToast("프로젝트 인원이 성공적으로 대체되었습니다.");
     isReplacementVisible.value = false;
     isReplacementMode.value = false;
 
     const response = await fetchProjectDetail(projectCode);
     project.value = response.data.data;
   } catch (e) {
-    console.error("인재 대체 실패", e);
-    showErrorToast("대체에 실패했습니다.");
+    console.error("프로젝트 인원 대체 실패", e);
+    showErrorToast("프로젝트 인원 대체에 실패했습니다.");
   }
 };
 </script>
@@ -332,6 +332,7 @@ const handleReplace = async ({ oldMember, newMember }) => {
       </div>
     </transition>
     <ReplacementPanel
+      :key="replacingMember?.employeeId"
       :project="project"
       v-show="isReplacementVisible"
       :leaving-member="replacingMember"

--- a/src/features/project/views/ProjectDetailView.vue
+++ b/src/features/project/views/ProjectDetailView.vue
@@ -10,15 +10,18 @@ import {
   deleteProject,
   updateProject,
   analyzeProject,
+  replaceProjectSquad,
 } from "@/api/project";
 import { showSuccessToast, showErrorToast } from "@/utills/toast";
 import { useAuthStore } from "@/stores/auth.js";
+import ReplacementPanel from "@/features/project/components/ReplacementPanel.vue";
 
 const route = useRoute();
 const router = useRouter();
 const project = ref(null);
 const isLoading = ref(true);
 const isEditVisible = ref(false);
+const projectCode = route.params.projectCode;
 const authStore = useAuthStore();
 const memberRole = computed(() => authStore.memberRole);
 
@@ -27,6 +30,11 @@ onMounted(async () => {
   try {
     const response = await fetchProjectDetail(projectCode);
     project.value = response.data.data;
+
+    if (project.value?.members?.length > 0) {
+      replacingMember.value = project.value.members[0];
+      console.log(replacingMember.value);
+    }
   } catch (error) {
     console.error("프로젝트 상세 정보 로드 실패:", error);
   } finally {
@@ -38,7 +46,6 @@ function handleComplete() {
   const confirm = window.confirm("정말 프로젝트를 종료하시겠습니까?");
   if (!confirm) return;
 
-  const projectCode = route.params.projectCode;
   updateProjectStatus(projectCode, "COMPLETE")
     .then(() => {
       project.value.status = "COMPLETE";
@@ -54,7 +61,6 @@ function handleDelete() {
   const confirmDelete = window.confirm("정말 이 프로젝트를 삭제하시겠습니까?");
   if (!confirmDelete) return;
 
-  const projectCode = route.params.projectCode;
   deleteProject(projectCode)
     .then(() => {
       showSuccessToast("프로젝트가 삭제되었습니다.");
@@ -67,8 +73,6 @@ function handleDelete() {
 }
 
 async function handleEditSubmit(data) {
-  const projectCode = route.params.projectCode;
-
   try {
     await updateProject(projectCode, data.payload);
     showSuccessToast("프로젝트가 수정되었습니다.");
@@ -84,6 +88,41 @@ async function handleEditSubmit(data) {
     showErrorToast("수정 중 오류가 발생했습니다.");
   }
 }
+
+const isReplacementMode = ref(false); // 대체 모드 진입 여부
+const isReplacementVisible = ref(false); // 패널 열림 여부
+const replacingMember = ref(null); // 현재 대체 대상 멤버
+
+const enterReplacementMode = () => {
+  isReplacementMode.value = true;
+  showSuccessToast("대체할 대상을 선택하세요.");
+};
+
+const handleMemberClick = (member) => {
+  if (isReplacementMode.value) {
+    replacingMember.value = member;
+    isReplacementVisible.value = true;
+  }
+};
+
+const handleReplace = async ({ oldMember, newMember }) => {
+  try {
+    await replaceProjectSquad({
+      squadCode: project.value.squadCode,
+      oldEmployeeId: oldMember.employeeId,
+      newEmployeeId: newMember.employeeId,
+    });
+    showSuccessToast("인재가 성공적으로 대체되었습니다.");
+    isReplacementVisible.value = false;
+    isReplacementMode.value = false;
+
+    const response = await fetchProjectDetail(projectCode);
+    project.value = response.data.data;
+  } catch (e) {
+    console.error("인재 대체 실패", e);
+    showErrorToast("대체에 실패했습니다.");
+  }
+};
 </script>
 
 <template>
@@ -186,18 +225,33 @@ async function handleEditSubmit(data) {
       <!-- 구성 인원 -->
       <div class="mb-2 flex justify-between items-center">
         <h2 class="font-semibold">구성 인원</h2>
-        <button
-          class="text-sm text-blue-500"
-          @click="router.push({ name: 'squad-list' })"
-        >
-          스쿼드 수정
-        </button>
+        <template v-if="['WAITING', 'IN_PROGRESS'].includes(project.status)">
+          <button
+            class="text-sm text-blue-500"
+            @click="
+              project.status === 'WAITING'
+                ? router.push(
+                    `/squads/create/${projectCode}?squadCode=${project.squadCode}`,
+                  )
+                : enterReplacementMode()
+            "
+          >
+            {{ project.status === "WAITING" ? "스쿼드 수정" : "인재 대체" }}
+          </button>
+        </template>
       </div>
+
+      <p
+        v-if="isReplacementMode"
+        class="text-sm text-red-500 mb-2 font-medium animate-fade"
+      >
+        대체할 개발자를 선택하세요.
+      </p>
 
       <div class="rounded-md overflow-hidden border-y border-gray-200">
         <div
           v-if="project.members.length > 0"
-          class="rounded-md bg-[#F7FAFC] divide-y max-h-80 overflow-y-auto"
+          class="rounded-md bg-[#F7FAFC] divide-y-2 max-h-80"
         >
           <SquadCard
             v-for="(member, idx) in project.members"
@@ -206,6 +260,11 @@ async function handleEditSubmit(data) {
             :role="member.job"
             :isLeader="member.isLeader"
             :imageUrl="member.imageUrl"
+            :selected="
+              isReplacementMode &&
+              replacingMember?.employeeId === member.employeeId
+            "
+            @click="handleMemberClick(member)"
           />
         </div>
         <div v-else class="p-6 text-center text-gray-400 text-sm bg-[#F7FAFC]">
@@ -272,6 +331,13 @@ async function handleEditSubmit(data) {
         </div>
       </div>
     </transition>
+    <ReplacementPanel
+      :project="project"
+      v-show="isReplacementVisible"
+      :leaving-member="replacingMember"
+      @close="isReplacementVisible = false"
+      @replace="handleReplace"
+    />
   </div>
 </template>
 

--- a/src/features/squad/components/SquadCard.vue
+++ b/src/features/squad/components/SquadCard.vue
@@ -69,7 +69,7 @@ async function handleShareSquad(adminList) {
       <!-- 헤더 영역 -->
       <div class="flex items-start justify-between mb-4">
         <h3 class="text-lg font-bold truncate max-w-[70%]">
-          스쿼드 {{ squad.squadCode?.split("_").pop() }}
+          {{ squad.squadName }}
         </h3>
         <div
           v-if="squad.aiRecommended"

--- a/src/features/squad/components/create/ManualDeveloperList.vue
+++ b/src/features/squad/components/create/ManualDeveloperList.vue
@@ -114,25 +114,56 @@ function toggleSort() {
   showSort.value = !showSort.value;
 }
 
+const statusMap = {
+  AVAILABLE: "대기중",
+  IN_PROJECT: "투입중",
+};
+
+const freelancerMap = {
+  INSIDER: "내부인",
+  OUTSIDER: "프리랜서",
+};
+
+const sortByMap = {
+  이름: "employeeName",
+  등급: "grade",
+};
+
+const sortOrderMap = {
+  오름차순: "asc",
+  내림차순: "desc",
+};
+
 function renderSummary() {
   const parts = [];
 
   if (selectedFilters.value.techStacks.length) {
     parts.push(selectedFilters.value.techStacks.join(", "));
   }
-  if (selectedFilters.value.grades.length) {
-    parts.push(selectedFilters.value.grades.join(", "));
-  }
-  if (selectedFilters.value.statuses.length) {
-    parts.push(selectedFilters.value.statuses.join(", "));
+  if (selectedFilters.value.sortBy || selectedFilters.value.sortOrder) {
+    const sortByLabel =
+      Object.entries(sortByMap).find(
+        ([, value]) => value === selectedFilters.value.sortBy,
+      )?.[0] || selectedFilters.value.sortBy;
+
+    const sortOrderLabel =
+      Object.entries(sortOrderMap).find(
+        ([, value]) => value === selectedFilters.value.sortOrder,
+      )?.[0] || selectedFilters.value.sortOrder;
+
+    parts.push(`${sortByLabel}-${sortOrderLabel}`);
   }
   if (selectedFilters.value.freelancer) {
-    parts.push(selectedFilters.value.freelancer);
+    const freelancerLabel =
+      freelancerMap[selectedFilters.value.freelancer] ||
+      selectedFilters.value.freelancer;
+    parts.push(freelancerLabel);
   }
-  if (selectedFilters.value.sortBy || selectedFilters.value.sortOrder) {
-    parts.push(
-      `${selectedFilters.value.sortBy}-${selectedFilters.value.sortOrder}`,
-    );
+  if (selectedFilters.value.statuses.length) {
+    const statusLabels = selectedFilters.value.statuses
+      .map((status) => statusMap[status] || status)
+      .join(", ");
+    parts.push(statusLabels);
   }
 
   return parts.join(" / ");

--- a/src/features/squad/components/modal/FilterModal.vue
+++ b/src/features/squad/components/modal/FilterModal.vue
@@ -112,7 +112,6 @@ function handleKeydown(e) {
       </span>
     </div>
 
-    <!-- 이하 그대로 -->
     <label class="block font-medium mb-1 ml-0">등급</label>
     <div class="flex gap-2 mb-3">
       <label v-for="g in ['S', 'A', 'B', 'C', 'D']" :key="g">
@@ -126,7 +125,7 @@ function handleKeydown(e) {
       <label
         ><input
           type="checkbox"
-          value="대기중"
+          value="AVAILABLE"
           v-model="selectedFilters.statuses"
         />
         대기중</label
@@ -134,7 +133,7 @@ function handleKeydown(e) {
       <label
         ><input
           type="checkbox"
-          value="투입중"
+          value="IN_PROJECT"
           v-model="selectedFilters.statuses"
         />
         투입중</label
@@ -146,26 +145,18 @@ function handleKeydown(e) {
       <label
         ><input
           type="radio"
-          value="포함"
+          value="INSIDER"
           v-model="selectedFilters.freelancer"
         />
-        프리랜서 포함</label
+        내부인</label
       >
       <label
         ><input
           type="radio"
-          value="내부인"
+          value="OUTSIDER"
           v-model="selectedFilters.freelancer"
         />
-        내부인만</label
-      >
-      <label
-        ><input
-          type="radio"
-          value="프리랜서"
-          v-model="selectedFilters.freelancer"
-        />
-        프리랜서만</label
+        프리랜서</label
       >
     </div>
   </div>

--- a/src/features/squad/components/modal/SortModal.vue
+++ b/src/features/squad/components/modal/SortModal.vue
@@ -3,7 +3,6 @@ import { watch } from "vue";
 
 const props = defineProps(["selectedFilters"]);
 
-// 매핑 테이블 정의
 const sortByMap = {
   이름: "employeeName",
   등급: "grade",

--- a/src/features/squad/views/SquadCreateView.vue
+++ b/src/features/squad/views/SquadCreateView.vue
@@ -18,10 +18,8 @@ onMounted(async () => {
 <template>
   <section class="squad-create-container">
     <div class="layout">
-      <!-- 좌측: 스쿼드 구성 패널 -->
       <SquadCreateSection />
 
-      <!-- 우측: 개발자 조회 패널 -->
       <div class="flex-1">
         <SquadFilterSection />
       </div>

--- a/src/features/squad/views/SquadListView.vue
+++ b/src/features/squad/views/SquadListView.vue
@@ -160,7 +160,6 @@ const openMoreModal = (type) => {
 };
 
 onMounted(() => {
-  const route = useRoute();
   selectedProjectCode.value = route.query.projectId;
   fetchProjects();
 });

--- a/src/features/squad/views/SquadListView.vue
+++ b/src/features/squad/views/SquadListView.vue
@@ -16,22 +16,22 @@ const totalCount = ref(0); // 총 스쿼드 수
 const toast = useToast();
 
 const showMoreModal = ref(false);
-const selectedMoreType = ref(""); // 예: 'waiting', 'inprogress', 'complete'
+const selectedMoreType = ref("");
 
 const squads = ref([]);
 const page = ref(1);
 const size = 9;
 const totalPages = ref(1);
 
-const selectedProjectCode = ref("");
+const route = useRoute();
+
+const selectedProjectCode = ref();
 const selectedProjectTitle = ref("");
 const selectedProjectStatus = computed(() => {
   return (
     projectMap.value[selectedProjectCode.value]?.status?.toUpperCase() ?? ""
   );
 });
-
-const route = useRoute();
 
 const projectGroups = ref({ waiting: [], inprogress: [], complete: [] });
 const projectMap = ref({}); // title → { projectCode, title, status }
@@ -159,7 +159,11 @@ const openMoreModal = (type) => {
   showMoreModal.value = true;
 };
 
-onMounted(fetchProjects);
+onMounted(() => {
+  const route = useRoute();
+  selectedProjectCode.value = route.query.projectId;
+  fetchProjects();
+});
 </script>
 
 <template>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -24,7 +24,7 @@ const routes = [
         return { name: "login" }; // 미로그인 시 로그인 페이지로
       }
       if (authStore.memberRole === "ADMIN") {
-        return { path: "/developers" }; // 관리자면 도메인 관리로
+        return { name: "AdminDashboardView" }; // 관리자면 대시보드로 이동
       }
       return { path: `/developers/dashboard` }; // 그 외는 자신의 프로필로
     },


### PR DESCRIPTION
## 🪐 작업 내용
### 관리자 메인 대시보드
- 관리자 메인 대시보드 UI 구현 및 api 연결했습니다.
- 알람의 경우엔 동적으로 조회되어야 하는 데이터이기도 하고 아직 확실하지 않아서 더미 데이터로 UI만 구현했으니 참고 부탁드립니다.

### 프로젝트 인원 보충 기능 구현 
- 프로젝트 진행 상태에 따라 진행 전에는 기존 스쿼드 수정 처럼 스쿼드 전체를 한번에 수정할 수 있도록 스쿼드 수정 페이지로 이동하게 했고 프로젝트가 진행하면 멤버를 대체하는 기능으로 구현했습니다.
- 인원 대체 버튼 클릭 -> 대체 가능한 상태가 되고 이 상황에서 대체 가능한 멤버를 클릭하면 개발자를 검색할 수 있거나 추천 받을 수 있는 패널이 슬라이드로 등장하도록 구현했습니다.

### 프로젝트 평가
- 프로젝트 이력 업로드에 대한 기능은 현재 개발자가 이력 올리고 관리자가 승인/거절 하는거만 구현되어 있어서 프로젝트 내역에서 해당 흐름이 보이는 기능 구현중입니다.(진행중)

## ✅ 체크리스트
- [ ] 이슈 완료
- [ ] cypress 통합테스트
- [ ] vitest 단위테스트
