### PR TITLE
[refactor] 로그인 권한별 메인 대시보드 이동 문제 해결

### DIFF
--- a/src/features/admin/router.js
+++ b/src/features/admin/router.js
@@ -1,6 +1,6 @@
 export const adminRoutes = [
   {
-    path: "/",
+    path: "/admin/dashboard",
     name: "AdminDashboardView",
     component: () => import("./views/AdminDashboardView.vue"),
     meta: {

--- a/src/features/auth/views/LoginView.vue
+++ b/src/features/auth/views/LoginView.vue
@@ -15,7 +15,11 @@ const handleLogin = async (payload) => {
     const at = resp.data.data.accessToken;
     authStore.setAuth(at);
     showSuccessToast("로그인 되었습니다.");
-    await router.push("/");
+    await router.replace(
+      authStore.memberRole === "ADMIN"
+        ? "/admin/dashboard"
+        : "/self-development/dashboard",
+    );
   } catch (error) {
     console.error("로그인 실패:", error.response.data.message);
     showErrorToast(error.response.data.message);

--- a/src/features/auth/views/LoginView.vue
+++ b/src/features/auth/views/LoginView.vue
@@ -17,8 +17,8 @@ const handleLogin = async (payload) => {
     showSuccessToast("로그인 되었습니다.");
     await router.replace(
       authStore.memberRole === "ADMIN"
-        ? "/admin/dashboard"
-        : "/self-development/dashboard",
+        ? { name: "AdminDashboardView" }
+        : { name: "developer-dashboard" },
     );
   } catch (error) {
     console.error("로그인 실패:", error.response.data.message);

--- a/src/features/developer/router.js
+++ b/src/features/developer/router.js
@@ -70,6 +70,7 @@ export const developerRoutes = [
     name: "developer-dashboard",
     component: () => import("./views/DashboardView.vue"),
     meta: {
+      requiresAuth: true,
       roles: ["INSIDER", "OUTSIDER"],
     },
   },

--- a/src/features/developer/router.js
+++ b/src/features/developer/router.js
@@ -66,8 +66,11 @@ export const developerRoutes = [
     },
   },
   {
-    path: "/developers/dashboard",
+    path: "/self-development/dashboard",
     name: "developer-dashboard",
     component: () => import("./views/DashboardView.vue"),
+    meta: {
+      roles: ["INSIDER", "OUTSIDER"],
+    },
   },
 ];

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -13,6 +13,12 @@ import { useAuthStore } from "@/stores/auth.js";
 import { showErrorToast } from "@/utills/toast.js";
 import { freelancerRoutes } from "@/features/freelancer/router.js";
 
+const getDashboardRouteByRole = (role) => {
+  return role === "ADMIN"
+    ? { name: "AdminDashboardView" }
+    : { name: "developer-dashboard" };
+};
+
 const routes = [
   {
     path: "/",
@@ -21,9 +27,7 @@ const routes = [
     redirect: () => {
       const authStore = useAuthStore();
       if (!authStore.isAuthenticated) return { name: "login" };
-      return authStore.memberRole === "ADMIN"
-        ? { path: "/admin/dashboard" }
-        : { path: "/self-development/dashboard" };
+      return getDashboardRouteByRole(authStore.memberRole);
     },
     children: [
       ...developerRoutes,
@@ -57,16 +61,12 @@ router.beforeEach((to) => {
     (to.name === "login" || to.name === "signup") &&
     authStore.isAuthenticated
   ) {
-    return authStore.memberRole === "ADMIN"
-      ? { path: "/admin/dashboard" }
-      : { path: "/self-development/dashboard" };
+    return getDashboardRouteByRole(authStore.memberRole);
   }
 
   // guestOnly 접근 시
   if (to.meta.guestOnly && authStore.isAuthenticated) {
-    return authStore.memberRole === "ADMIN"
-      ? { path: "/admin/dashboard" }
-      : { path: "/self-development/dashboard" };
+    return getDashboardRouteByRole(authStore.memberRole);
   }
 
   // 권한 체크

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -20,13 +20,10 @@ const routes = [
     component: AppShell,
     redirect: () => {
       const authStore = useAuthStore();
-      if (!authStore.isAuthenticated) {
-        return { name: "login" }; // 미로그인 시 로그인 페이지로
-      }
-      if (authStore.memberRole === "ADMIN") {
-        return { name: "AdminDashboardView" }; // 관리자면 대시보드로 이동
-      }
-      return { path: `/developers/dashboard` }; // 그 외는 자신의 프로필로
+      if (!authStore.isAuthenticated) return { name: "login" };
+      return authStore.memberRole === "ADMIN"
+        ? { path: "/admin/dashboard" }
+        : { path: "/self-development/dashboard" };
     },
     children: [
       ...developerRoutes,
@@ -46,53 +43,53 @@ const router = createRouter({
   routes,
 });
 
-// 전역 가드: 인증 · 권한 · guestOnly · 로그인/회원가입 접근 제어
-router.beforeEach((to, from) => {
+router.beforeEach((to) => {
   const authStore = useAuthStore();
-  // 1) 인증 필요 페이지인데 비로그인
+
+  // 로그인 필요
   if (to.meta.requiresAuth && !authStore.isAuthenticated) {
     showErrorToast("로그인이 필요한 페이지입니다.");
-    return { path: `/login` };
+    return { name: "login" };
   }
 
-  // 2) 로그인한 상태로 login/signup 접근 금지
+  // 로그인, 회원가입 접근 시
   if (
     (to.name === "login" || to.name === "signup") &&
     authStore.isAuthenticated
   ) {
-    showErrorToast("이미 로그인된 상태입니다.");
-    return { path: `/developers/${authStore.memberId}` };
+    return authStore.memberRole === "ADMIN"
+      ? { path: "/admin/dashboard" }
+      : { path: "/self-development/dashboard" };
   }
 
-  // 3) guestOnly 페이지 접근 금지
+  // guestOnly 접근 시
   if (to.meta.guestOnly && authStore.isAuthenticated) {
-    return { path: `/developers/${authStore.memberId}` };
+    return authStore.memberRole === "ADMIN"
+      ? { path: "/admin/dashboard" }
+      : { path: "/self-development/dashboard" };
   }
 
-  // 4) roles 메타로 권한 체크
+  // 권한 체크
   const { roles } = to.meta;
-  console.log(roles);
-  console.log(authStore.memberRole);
   if (
     Array.isArray(roles) &&
     roles.length > 0 &&
     !roles.includes(authStore.memberRole)
   ) {
     showErrorToast("접근 권한이 없습니다.");
-    return { path: `/developers/${authStore.memberId}` };
+    return false;
   }
 
+  // allowSelfOrAdmin 체크
   if (to.meta.allowSelfOrAdmin) {
     const targetId = to.params.employeeId;
-    const isAdmin = authStore.memberRole === "ADMIN";
-    const isSelf = authStore.memberId === targetId;
-
-    if (!isAdmin && !isSelf) {
+    if (
+      !(authStore.memberRole === "ADMIN" || authStore.memberId === targetId)
+    ) {
       showErrorToast("접근 권한이 없습니다.");
-      return { path: `/developers/${authStore.memberId}` };
+      return false;
     }
   }
-  // 정상 진행
 });
 
 export default router;


### PR DESCRIPTION
## 🪐 작업 내용
- 로그인 성공 시 역할에 따른 다른 메인 대시보드로 이동하도록 변경했습니다
- 전역 가드에서도 인증이 되었는데 로그인, 회원가입 접근 시 역할에 따라 다른 대시보드 이동하도록 변경했습니다. 


<br>

## 📚 논의하고 싶은 내용 (선택)
- 선택사항


<br>

## ✅ 체크리스트
- [ ] 이슈 완료
- [ ] cypress 통합테스트
- [ ] vitest 단위테스트
