### PR TITLE
[feat] 프로젝트 세부사항 페이지에서 구성원 프로젝트 이력 흐름 보이도록 구현

### DIFF
--- a/src/api/project.js
+++ b/src/api/project.js
@@ -125,5 +125,5 @@ export function replaceRecommendation(payload) {
 }
 
 export function fetchDeveloperApprovals(projectCode) {
-  return api.get(`/projects/${projectCode}/developer-approvals`);
+  return api.get(`/dev-project-works/${projectCode}/developer-approvals`);
 }

--- a/src/features/project/components/SquadCard.vue
+++ b/src/features/project/components/SquadCard.vue
@@ -1,19 +1,22 @@
 <template>
   <div
     :class="[
-      'flex items-center justify-between px-6 py-4 transition-all duration-200',
-      approvalStatus !== 'APPROVED' ? 'opacity-50' : 'opacity-100',
-      isLeader === 1 && isReplacementMode
-        ? 'cursor-not-allowed bg-gray-100'
-        : selected
-          ? 'cursor-pointer bg-yellow-50 border-yellow-400 border-2 rounded-md'
-          : isReplacementMode
-            ? 'cursor-pointer hover:bg-yellow-50'
-            : 'cursor-pointer bg-[#F7FAFC]',
+      'flex items-center justify-between px-6 py-4 transition-all duration-200 relative group',
+      isEvaluationMode && approvalStatus === 'NOT_REQUESTED'
+        ? 'opacity-50'
+        : 'opacity-100',
+      approvalStatus === 'APPROVED'
+        ? 'bg-green-50'
+        : isLeader === 1 && isReplacementMode
+          ? 'cursor-not-allowed bg-gray-100'
+          : selected
+            ? 'cursor-pointer bg-yellow-50 border-yellow-400 border-2 rounded-md'
+            : isReplacementMode
+              ? 'cursor-pointer hover:bg-yellow-50'
+              : 'cursor-pointer bg-[#F7FAFC]',
     ]"
     @click="handleClick"
   >
-    <!-- 프로필 + 이름/직무 -->
     <div class="flex items-center gap-4">
       <img
         :src="imageUrl"
@@ -23,7 +26,6 @@
       <div>
         <div class="flex items-center gap-1">
           <p class="text-sm font-semibold text-gray-800">{{ name }}</p>
-          <!-- 리더 아이콘 -->
           <svg
             v-if="isLeader === 1"
             xmlns="http://www.w3.org/2000/svg"
@@ -33,7 +35,6 @@
           >
             <path d="M5 16h14v2H5v-2Zm14-8-4 4-3-3-3 3-4-4-1 6h16l-1-6Z" />
           </svg>
-          <!-- 승인 상태 아이콘 -->
           <svg
             v-if="approvalStatus === 'APPROVED'"
             xmlns="http://www.w3.org/2000/svg"
@@ -51,9 +52,22 @@
         <p class="text-xs text-blue-600">{{ role }}</p>
       </div>
     </div>
-    <p class="text-xs text-gray-500 capitalize">
-      {{ statusText }}
-    </p>
+
+    <template v-if="isEvaluationMode && approvalStatus === 'PENDING'">
+      <a
+        :href="`/projects/history/${historyId}`"
+        class="absolute right-6 top-1/2 -translate-y-1/2 px-4 py-2 text-xs font-semibold text-white bg-blue-500 rounded-md transform translate-x-full group-hover:translate-x-0 transition-all duration-300"
+        @click.stop
+      >
+        프로젝트 이력 내역 확인하기 →
+      </a>
+    </template>
+
+    <template v-if="isEvaluationMode">
+      <p class="text-xs text-gray-500 capitalize pr-3">
+        {{ statusText }}
+      </p>
+    </template>
   </div>
 </template>
 
@@ -78,6 +92,14 @@ const props = defineProps({
   approvalStatus: {
     type: String,
     default: "NOT_REQUESTED",
+  },
+  isEvaluationMode: {
+    type: Boolean,
+    default: false,
+  },
+  historyId: {
+    type: String,
+    required: false,
   },
 });
 

--- a/src/features/project/components/SquadCard.vue
+++ b/src/features/project/components/SquadCard.vue
@@ -54,13 +54,13 @@
     </div>
 
     <template v-if="isEvaluationMode && approvalStatus === 'PENDING'">
-      <a
-        :href="`/projects/history/${historyId}`"
+      <router-link
+        :to="`/projects/history/${historyId}`"
         class="absolute right-6 top-1/2 -translate-y-1/2 px-4 py-2 text-xs font-semibold text-white bg-blue-500 rounded-md transform translate-x-full group-hover:translate-x-0 transition-all duration-300"
         @click.stop
       >
         프로젝트 이력 내역 확인하기 →
-      </a>
+      </router-link>
     </template>
 
     <template v-if="isEvaluationMode">

--- a/src/features/project/views/ProjectDetailView.vue
+++ b/src/features/project/views/ProjectDetailView.vue
@@ -41,7 +41,6 @@ function handleEvaluate() {
 }
 
 function handleComplete() {
-  console.log("clicked??");
   const confirm = window.confirm("프로젝트 평가를 종료하겠습니까?");
   if (!confirm) return;
 
@@ -210,7 +209,6 @@ const approvedCount = computed(
         <template v-if="project.status === 'EVALUATION'">
           <button
             v-if="memberRole === 'ADMIN'"
-            class="bg-gray-300 text-gray-600 px-5 py-2 rounded-md"
             :class="[
               'px-5 py-2 rounded-md font-semibold',
               Object.values(approvalStatusMap).every(

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -69,6 +69,11 @@ router.beforeEach((to) => {
     return getDashboardRouteByRole(authStore.memberRole);
   }
 
+  // / 접근 시 → 권한별 대시보드 이동
+  if (to.path === "/" && authStore.isAuthenticated) {
+    return getDashboardRouteByRole(authStore.memberRole);
+  }
+
   // 권한 체크
   const { roles } = to.meta;
   if (

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -69,11 +69,6 @@ router.beforeEach((to) => {
     return getDashboardRouteByRole(authStore.memberRole);
   }
 
-  // / 접근 시 → 권한별 대시보드 이동
-  if (to.path === "/" && authStore.isAuthenticated) {
-    return getDashboardRouteByRole(authStore.memberRole);
-  }
-
   // 권한 체크
   const { roles } = to.meta;
   if (


### PR DESCRIPTION
## 🪐 작업 내용
- 제목과 동일하게  프로젝트 세부사항 페이지에서 구성원 프로젝트 이력 흐름 보이도록 구현했습니다. 
- 구성원별 이력 등록 상태에 따라 시각적으로 구분되게 구현했고 프로젝트 이력을 등록한 상태(PENDING)라면 해당 이력을 확인하고 승인할 수 있는 곳으로 이동하도록 구현했습니다. 
- 모든 구성원의 프로젝트 이력이 승인되었다면 프로젝트 세부사항 페이지에서 평가 종료 버튼이 활성화되고 실제 프로젝트 종료 일자가 찍히면서 종료되도록 구성했습니다. 
- 
<br>

## 📚 논의하고 싶은 내용 (선택)
- 선택사항


<br>

## ✅ 체크리스트
- [o] 이슈 완료
- [x] cypress 통합테스트
- [x] vitest 단위테스트
