### PR TITLE
[fix] 교육 추천 카드에서 교육 카테고리 표시되지 않는 문제 수정

### DIFF
--- a/src/features/developer/components/TrainingCard.vue
+++ b/src/features/developer/components/TrainingCard.vue
@@ -31,10 +31,10 @@
       <div>
         <!-- 카테고리 -->
         <p
-          v-if="category"
+          v-if="trainingCategory"
           class="text-xs inline-block bg-gray-100 text-blue-600 font-semibold px-2 py-0.5 rounded-full mb-1"
         >
-          {{ category }}
+          {{ trainingCategory }}
         </p>
 
         <!-- 교육명 -->
@@ -64,7 +64,7 @@ const {
   description,
   reason,
   thumbnailUrl,
-  category,
+  trainingCategory,
   organization,
   videoUrl,
 } = defineProps({
@@ -72,7 +72,7 @@ const {
   description: String,
   reason: String,
   thumbnailUrl: String,
-  category: String,
+  trainingCategory: String,
   organization: String,
   videoUrl: String,
 });

--- a/src/features/developer/views/TrainingRecommendationView.vue
+++ b/src/features/developer/views/TrainingRecommendationView.vue
@@ -21,7 +21,7 @@
           :description="training.trainingDescription"
           :reason="training.recommendationReason"
           :thumbnailUrl="training.imageUrl"
-          :category="training.category"
+          :trainingCategory="training.trainingCategory"
           :organization="training.organization"
           :videoUrl="training.videoUrl"
         />


### PR DESCRIPTION
## 🛰️ Issue
Closes #n


<br>

## 🪐 작업 내용
변수명 변경 category -> traingingCatagory


<br>

## 📚 논의하고 싶은 내용 (선택)
- 선택사항


<br>

## ✅ 체크리스트
- [x] 이슈 완료
- [ ] cypress 통합테스트
- [ ] vitest 단위테스트
