### PR TITLE
[fix]: 프로젝트 수정 오류를 수정

### DIFF
--- a/src/features/project/views/ProjectDetailView.vue
+++ b/src/features/project/views/ProjectDetailView.vue
@@ -92,13 +92,16 @@ async function handleEditSubmit(data) {
     await updateProject(projectCode, data.payload);
     showSuccessToast("프로젝트가 수정되었습니다.");
 
-    await analyzeProject(projectCode, data.file);
+    if (data.file) {
+      await analyzeProject(projectCode, data.file);
+    }
 
     // UI 반영
     Object.assign(project.value, data.payload);
 
     isEditVisible.value = false;
   } catch (error) {
+    console.log(error);
     showErrorToast("수정 중 오류가 발생했습니다.");
   }
 }


### PR DESCRIPTION
## 🛰️ Issue
Closes #265


<br>

## 🪐 작업 내용
프로젝트 수정할 때 요구사항 명세서를 수정하지 않고 수정 버튼을 누르면 나는 오류가 있었습니다.
요구사항 명세서를 수정하지 않는다면 그 부분은 오류 처리를 안 하도록 한 차례 필터링 해두었습니다. (회의 때 성용씨가 카톡으로 말한 부분)


<br>

## 📚 논의하고 싶은 내용 (선택)
- 선택사항


<br>

## ✅ 체크리스트
- [x] 이슈 완료
- [ ] cypress 통합테스트
- [ ] vitest 단위테스트
