### PR TITLE
[fix] 통계 - 지속적인 경고 콘솔 문제 해결

### DIFF
--- a/src/features/statistics/views/GradeSalaryView.vue
+++ b/src/features/statistics/views/GradeSalaryView.vue
@@ -81,7 +81,7 @@ function renderChart() {
       scales: {
         y: {
           beginAtZero: true,
-          ticks: { stepSize: 1, precision: 0 },
+          precision: 0,
         },
       },
     },

--- a/src/features/statistics/views/GradeSalaryView.vue
+++ b/src/features/statistics/views/GradeSalaryView.vue
@@ -81,7 +81,7 @@ function renderChart() {
       scales: {
         y: {
           beginAtZero: true,
-          precision: 0,
+          ticks: { precision: 0 },
         },
       },
     },


### PR DESCRIPTION
## 🛰️ Issue
Closes #273


<br>

## 🪐 작업 내용
경고 원인 : stepSize: 1로 인해 1,808,000,001개의 눈금을 생성하려고 시도함 → 너무 많아서 Chart.js가 1000개 이하로 제한하면서 경고 발생
해결 : Y축 눈금 수를 자동으로 조정하도록 함

<br>

## 📚 논의하고 싶은 내용 (선택)
- 선택사항


<br>

## ✅ 체크리스트
- [x] 이슈 완료
- [ ] cypress 통합테스트
- [ ] vitest 단위테스트
